### PR TITLE
ColumnFamily.isSuper

### DIFF
--- a/lib/column_family.js
+++ b/lib/column_family.js
@@ -85,7 +85,7 @@ function getSlicePredicate(options, serializer){
  */
 var ColumnFamily = function(keyspace, definition){
 //  ttype.CfDef.call(this, definition);
-  this.isSuper = this.column_type === 'Super';
+  this.isSuper = definition.column_type === 'Super';
   this.keyspace = keyspace;
   this.connection = keyspace.connection;
   this.definition = definition;

--- a/test/helpers/thrift.json
+++ b/test/helpers/thrift.json
@@ -2,6 +2,7 @@
   "keyspace"     : "helenus_test_keyspace",
   "cf_standard"  : "cf_standard_test",
   "cf_standard_composite"  : "cf_standard_composite_test",
+  "cf_supercolumn"  : "cf_supercolumn_test",
   "cf_invalid"   : "cf_invalid_test",
   "cf_error"     : "<!`~;/?}]|\\-",
   "cf_standard_options"   : {
@@ -28,6 +29,13 @@
     "key_validation_class"     : "CompositeType(UTF8Type, UUIDType)",
     "comparator_type"          : "CompositeType(LongType, DateType)",
     "default_validation_class" : "UTF8Type"
+  },
+  "cf_supercolumn_options" : {
+    "column_type" : "Super", 
+    "key_validation_class"  : "UTF8Type",
+    "default_validation_class" : "UTF8Type",
+    "comparator_type" : "UTF8Type",
+    "subcomparator_type" : "UTF8Type"
   },
   "standard_row_key" : "standard_row_1",
   "standard_insert_values" : {

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -47,6 +47,13 @@ module.exports = {
     });
   },
 
+  'test keyspace.createSuperColumnFamily':function(test, assert){
+    ks.createColumnFamily(config.cf_supercolumn, config.cf_supercolumn_options, function(err){
+      assert.ifError(err);
+      test.finish();
+    });
+  },
+
   'test keyspace.get':function(test, assert){
     ks.get(config.cf_standard, function(err, columnFamily){
       assert.ifError(err);
@@ -60,6 +67,15 @@ module.exports = {
       assert.ifError(err);
       assert.ok(columnFamily instanceof Helenus.ColumnFamily);
       cf_composite = columnFamily;
+      test.finish();
+    });
+  },
+
+  'test keyspace.get supercolumn':function(test, assert){
+    ks.get(config.cf_supercolumn, function(err, columnFamily){
+      assert.ifError(err);
+      assert.ok(columnFamily instanceof Helenus.ColumnFamily);
+      assert.ok(columnFamily.isSuper === true);
       test.finish();
     });
   },

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -58,6 +58,7 @@ module.exports = {
     ks.get(config.cf_standard, function(err, columnFamily){
       assert.ifError(err);
       assert.ok(columnFamily instanceof Helenus.ColumnFamily);
+      assert.ok(columnFamily.isSuper === false);
       test.finish();
     });
   },


### PR DESCRIPTION
I found a little issue in the ColumnFamily's constructor.  It currently sets the incorrect value for isSuper when you're trying to create a super column.  It's a very minor fix.  Please let me know if I need to make any changes.
