### PR TITLE
JSDoc git repo has moved

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     }
   , "devDependencies": {
       "whiskey": "git://github.com/cloudkick/whiskey.git#b3c5bc23e30c95e46083bc7628c2557c1c15ec95"
-    , "JSDoc": "git://github.com/micmath/jsdoc.git"
+    , "JSDoc": "git://github.com/jsdoc3/jsdoc.git"
     }
   , "scripts": {
       "test": "make test"


### PR DESCRIPTION
Helenus fails to install currently since the JSDoc repo has moved.
