### PR TITLE
Set default strategy_options in createKeyspace

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -390,14 +390,19 @@ Connection.prototype.createKeyspace = function(keyspace, options, callback){
     return;
   }
 
-  var ksdef = new ttype.KsDef({
+  var args = {
     name:keyspace,
     strategy_class: options.strategyClass || 'SimpleStrategy',
-    //strategy_options: options.strategyOptions || {},
+    strategy_options: options.strategyOptions || {},
     replication_factor: options.replication || 1,
     durable_writes: options.durable || true,
     cf_defs: []
-  });
+  };
+  if (args.strategy_class === 'SimpleStrategy' &&
+      !args.strategy_options.replication_factor) {
+    args.strategy_options.replication_factor = '' + args.replication_factor;
+  }
+  var ksdef = new ttype.KsDef(args);
 
   /**
    * Once finished, fix the error if needed


### PR DESCRIPTION
- C\* 1.1 (currently in beta) requires replication_factor to be set when using SimpleStrategy

Otherwise the current test will raise:

```
Exception
HelenusInvalidRequestException: SimpleStrategy requires a replication_factor strategy option.
```
