### PR TITLE
Pool without keyspace but with close event

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -33,6 +33,7 @@ var Pool = function(options){
   this.password = options.password;
   this.timeout = options.timeout;
   this.retryInterval = null;
+  this.closing = false;
 
   if(!options.hosts && options.host){
     this.hosts = [options.hosts];
@@ -68,7 +69,9 @@ Pool.prototype.connect = function(callback){
       //we only want to callback once, after we get a valid connection
       if(connected === 1){
         //set the keyspaces connection to be the pool
-        keyspace.connection = self;
+        if(keyspace){
+          keyspace.connection = self;
+        }
         callback(null, keyspace);
 
         //now that we have a connection, lets start monitoring
@@ -119,7 +122,9 @@ Pool.prototype.use = function(keyspace, callback){
     finished += 1;
     error = err;
     ks = keyspace;
-    keyspace.connection = self;
+    if(keyspace){
+      keyspace.connection = self;
+    }
     
     if(finished === len){
       callback(error, ks);
@@ -212,6 +217,11 @@ Pool.prototype.dropKeyspace = function(name, callback){
 Pool.prototype.monitorConnections = function(){
   var self = this;
 
+  // If the pool is already closing, don't bother about monitoring connections
+  if(self.closing){
+    return;
+  }
+
   /**
    * Try to connect, if success then add to the client pool, if fail the add to the dead pool.
    */
@@ -254,10 +264,21 @@ Pool.prototype.monitorConnections = function(){
  * Closes all open connections
  */
 Pool.prototype.close = function(){
-  var i = 0, len = this.clients.length;
+  var self = this, i = 0, j = 0, len = this.clients.length;
+
+  // Make sure no intervals get set
+  self.closing = true;
+
   clearInterval(this.retryInterval);
 
+  function closed(){
+    j++;
+    if(j === len){
+      self.emit('close');
+    }
+  }
   for(; i < len; i += 1){
+    this.clients[i].on('close', closed);
     this.clients[i].close();
   }
 };

--- a/test/helpers/connection.json
+++ b/test/helpers/connection.json
@@ -1,6 +1,5 @@
 {
   "hosts"      : ["localhost:9160"],
-  "keyspace"   : "system",
   "user"       : "test",
   "password"   : "test1233",
   "timeout"    : 3000 

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -5,11 +5,30 @@ var config = require('./helpers/thrift'),
 module.exports = {
   'setUp':function(test, assert){
     Helenus = require('helenus');
-    conn = new Helenus.ConnectionPool(system);
     test.finish();
   },
 
-  'test pool.connect':function(test, assert){
+  'test pool.connect without keyspace':function(test, assert){
+    conn = new Helenus.ConnectionPool(system);
+    conn.connect(function(err, keyspace){
+      assert.ifError(err);
+      assert.strictEqual(keyspace, undefined);
+      test.finish();
+    });
+  },
+
+  'test pool.close without keyspace':function(test, assert){
+    conn.on('close', function(){
+      test.finish();
+    });
+    assert.doesNotThrow(function(){
+      conn.close();
+    });
+  },
+
+  'test pool.connect with keyspace':function(test, assert){
+    system.keyspace = 'system';
+    conn = new Helenus.ConnectionPool(system);
     conn.connect(function(err, keyspace){
       assert.ifError(err);
       assert.ok(keyspace.definition.name === 'system');
@@ -499,8 +518,12 @@ module.exports = {
   },
 
   'test pool.close':function(test, assert){
-    assert.doesNotThrow(function(){ conn.close(); });
-    test.finish();
+    conn.on('close', function(){
+      test.finish();
+    });
+    assert.doesNotThrow(function(){
+      conn.close();
+    });
   },
 
   'tearDown':function(test, assert){


### PR DESCRIPTION
When adding a test case for the keyspace-less connects I stumbled upon the problem, that a pool doesn't emit a close event as soon as all client connections have been closed.

This patch adds both, keyspaceless connects, and emission of closeevents by pools.

However something still goes wrong in the thrift test where a connection is now opened, then closed, then opened again and closed again. The test times out in the and. Apparently some connection still remains open.

Could anyone look into this? I'm stuck.
