### PR TITLE
Store DateType fields in milliseconds, not microseconds.

### DIFF
--- a/lib/marshal/deserializers.js
+++ b/lib/marshal/deserializers.js
@@ -110,7 +110,7 @@ Deserializers.decodeBoolean = function(val){
  */
 Deserializers.decodeDate = function(val){
   var date = Deserializers.decodeLong(val);
-  return new Date(date / 1000);
+  return new Date(date);
 };
 
 /**

--- a/lib/marshal/serializers.js
+++ b/lib/marshal/serializers.js
@@ -158,12 +158,12 @@ Serializers.encodeBoolean = function(val){
  * @static
  */
 Serializers.encodeDate = function(val){
-  var t = 1000;
+  var t;
 
   if(val instanceof Date){
-    t *= val.getTime();
+    t = val.getTime();
   } else {
-    t *= new Date(val).getTime();
+    t = new Date(val).getTime();
   }
 
   return Serializers.encodeLong(t);


### PR DESCRIPTION
The DateType serializer currently multiplies the millisecond timestamps by a factor of 1000 and the de-serializer corrects for that fact. This worked well by chance when using only the thrift part of this particular driver (that's why the tests pass) but results in wrong timestamps being stored that are off by a factor of 1000 in all other drivers.

See http://www.datastax.com/docs/1.0/references/cql/index#working-with-dates-and-times
and https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date
