### PR TITLE
Add support for Int32Type and DecimalType (not quite perfect yet)

### DIFF
--- a/lib/marshal/deserializers.js
+++ b/lib/marshal/deserializers.js
@@ -33,15 +33,6 @@ Deserializers.decodeLong = function(val){
 };
 
 /**
- * Decodes a 16bit Unsinged Integer
- * @param {String} val The binary string to decode
- * @returns {Number} The number value decoded from the binary string
- */
-Deserializers.decodeInt16 = function(val){
-  return Deserializers.decodeInteger(16, val);
-};
-
-/**
  * Decodes a 32bit Unsinged Integer
  * @param {String} val The binary string to decode
  * @returns {Number} The number value decoded from the binary string

--- a/lib/marshal/index.js
+++ b/lib/marshal/index.js
@@ -18,6 +18,7 @@ var TYPES = {
   'BytesType': { ser:Serializers.encodeBinary, de:Deserializers.decodeBinary },
   'LongType': { ser:Serializers.encodeLong, de:Deserializers.decodeLong },
   'IntegerType': { ser:Serializers.encodeInt32, de:Deserializers.decodeInt32 },
+  'Int32Type': { ser:Serializers.encodeInt32, de:Deserializers.decodeInt32 },
   'UTF8Type': { ser:Serializers.encodeUTF8, de:Deserializers.decodeUTF8 },
   'AsciiType': { ser:Serializers.encodeAscii, de:Deserializers.decodeAscii },
   'LexicalUUIDType': { ser:Serializers.encodeUUID, de:Deserializers.decodeUUID },
@@ -25,6 +26,7 @@ var TYPES = {
   'CounterColumnType': { ser:NOOP, de:NOOP },
   'FloatType': { ser:Serializers.encodeFloat, de:Deserializers.decodeFloat },
   'DoubleType':{ ser:Serializers.encodeDouble, de:Deserializers.decodeDouble },
+  'DecimalType':{ ser:Serializers.encodeDouble, de:Deserializers.decodeDouble },
   'DateType':{ ser:Serializers.encodeDate, de:Deserializers.decodeDate },
   'BooleanType':{ ser:Serializers.encodeBoolean, de:Deserializers.decodeBoolean },
   'UUIDType': { ser:Serializers.encodeUUID, de:Deserializers.decodeUUID }

--- a/lib/marshal/serializers.js
+++ b/lib/marshal/serializers.js
@@ -21,7 +21,6 @@ Serializers.encodeInteger = function(bits, num){
   }
 
   switch(bits){
-    case 16: buf.writeUInt16BE(num, 0); break;
     case 32: buf.writeUInt32BE(num, 0); break;
     case 64:
       var hex = num.toString(16);
@@ -55,16 +54,6 @@ Serializers.encodeBinary = function(val){
  */
 Serializers.encodeLong = function(val){
   return Serializers.encodeInteger(64, val);
-};
-
-/**
- * Encodes a 16bit Unsinged Integer
- * @param {Number} val The number to serialize into a 16-bit integer
- * @returns {Buffer} A buffer containing the value bytes
- * @static
- */
-Serializers.encodeInt16 = function(val){
-  return Serializers.encodeInteger(16, val);
 };
 
 /**


### PR DESCRIPTION
- DecimalType are java.math.BigDecimal which are encoded into javascript
  doubles for now
- IntegerType are java.math.BigInteger which are encoded into javascipt
  integers for now (might loose precision when doing math with them).

If you create a field of type `int` in CQL it will use `Int32Type` internally. This patch adds the missing marshaller. It also adds a placeholder for the missing `DecimalType`.

With this patch there should at least be some marshaller for all existing cassandra datatypes, although the marshallers for `LongType`, `IntegerType` and `DecimalType` may not be perfect yet.

Datatypes are described in the docs:
- http://www.datastax.com/docs/1.0/references/cql/index#cql-data-types
- http://www.datastax.com/docs/1.0/ddl/column_family#about-data-types-comparators-and-validators

I've also dropped support for 16 bit integers since cassandra has no corresponding data type (that I'm aware of).
