### PR TITLE
Adding Increment Operation

### DIFF
--- a/lib/column_family.js
+++ b/lib/column_family.js
@@ -135,7 +135,6 @@ function getColumns(columns, options){
   return arr;
 }
 
-
 /**
  * Gets a slcie predicate based on some options
  * @private

--- a/lib/column_family.js
+++ b/lib/column_family.js
@@ -1,6 +1,7 @@
 var util = require('util'),
     Marshal = require('./marshal'),
     Column = require('./column'),
+    CounterColumn = require('./counter_column'),
     Row = require('./row'),
     ttype = require('./cassandra/cassandra_types');
 
@@ -134,6 +135,7 @@ function getColumns(columns, options){
   return arr;
 }
 
+
 /**
  * Gets a slcie predicate based on some options
  * @private
@@ -170,6 +172,7 @@ function getSlicePredicate(options, serializer){
 var ColumnFamily = function(keyspace, definition){
 //  ttype.CfDef.call(this, definition);
   this.isSuper = definition.column_type === 'Super';
+  this.isCounter = definition.default_validation_class === 'org.apache.cassandra.db.marshal.CounterColumnType';
   this.keyspace = keyspace;
   this.connection = keyspace.connection;
   this.definition = definition;
@@ -379,6 +382,53 @@ ColumnFamily.prototype.getIndexed = function(query, options, callback){
   }
 
   this.connection.execute('get_indexed_slices', columnParent(self), indexClause, predicate, consistency, onComplete);
+};
+
+
+/**
+ * Increments a counter column.
+ * @param  {Object}   key      Row key
+ * @param  {Object}   column   Column name
+ * @param  {Number}   value    Integer to increase by, defaults to 1 (optional)
+ * @param  {Object}   options  The thrift options (optional)
+ * @param  {Function} callback The callback to call once complete
+ */
+ColumnFamily.prototype.incr = function (key, column, value, options, callback) {
+
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+
+  if (typeof value === 'function') {
+    callback = value;
+    options = {};
+    value = 1;
+  }
+
+  if (typeof value === 'object') {
+    options = value;
+    value = 1;
+  }
+
+
+  var mutations = [], batch = {}, col,
+    consistency = options.consistency || options.consistencyLevel || DEFAULT_WRITE_CONSISTENCY;
+
+  col = new CounterColumn(column, value);
+
+  mutations.push(new ttype.Mutation({
+    column_or_supercolumn: new ttype.ColumnOrSuperColumn({
+      counter_column: col.toThrift(this.columnMarshaller)
+    })
+  }));
+
+  var marshalledKey = this.keyMarshaller.serialize(key).toString('binary');
+
+  batch[marshalledKey] = {};
+  batch[marshalledKey][this.definition.name] = mutations;
+
+  this.connection.execute('batch_mutate', batch, consistency, callback);
 };
 
 module.exports = ColumnFamily;

--- a/lib/counter_column.js
+++ b/lib/counter_column.js
@@ -1,5 +1,4 @@
-var util = require('util'),
-    ttypes = require('./cassandra/cassandra_types');
+var ttypes = require('./cassandra/cassandra_types');
 
 /**
  * Cassandra Counter Column object representation

--- a/lib/counter_column.js
+++ b/lib/counter_column.js
@@ -1,0 +1,36 @@
+var util = require('util'),
+    ttypes = require('./cassandra/cassandra_types');
+
+/**
+ * Cassandra Counter Column object representation
+ * @param {Object} name The name of the column, can be any type, for composites use Array
+ * @param {Number} value The value to add to the counter, must be an integer.
+ * @constructor
+ */
+var CounterColumn = function(name, value){
+  /**
+   * The name of the column, can be any type, for composites use Array
+   */
+  this.name = name;
+
+  /**
+   * The value to add to the counter
+   */
+  this.value = value;
+
+};
+
+/**
+ * Marshals the counter column to a thrift counter column using the marshallers
+ * for name and value. Values are always numbers.
+ * @param {Marshal} nameMarshaller The marshaller for the column name
+ * @returns {CounterColumn} The thrift column with correctly marshalled name and value
+ */
+CounterColumn.prototype.toThrift = function(nameMarshaller){
+  return new ttypes.CounterColumn({
+    name: nameMarshaller.serialize(this.name),
+    value: this.value
+  });
+};
+
+module.exports = CounterColumn;

--- a/lib/helenus.js
+++ b/lib/helenus.js
@@ -54,6 +54,13 @@ Helenus.ColumnFamily = require('./column_family');
 Helenus.Column = require('./column');
 
 /**
+ * The CounterColumn
+ * @static
+ * @see  CounterColumn
+ */
+Helenus.CounterColumn = require('./counter_column');
+
+/**
  * The Row
  * @static
  * @see Row

--- a/lib/marshal/index.js
+++ b/lib/marshal/index.js
@@ -10,6 +10,13 @@ var Serializers = require('./serializers'),
 var NOOP = function(){};
 
 /**
+ * Returns the same value
+ * @private
+ * @memberOf Marshal
+ */
+var IDENTITY = function (val) { return val; };
+
+/**
  * Supported types for marshalling
  * @private
  * @memberOf Marshal
@@ -23,7 +30,7 @@ var TYPES = {
   'AsciiType': { ser:Serializers.encodeAscii, de:Deserializers.decodeAscii },
   'LexicalUUIDType': { ser:Serializers.encodeUUID, de:Deserializers.decodeUUID },
   'TimeUUIDType': { ser:Serializers.encodeTimeUUID, de:Deserializers.decodeTimeUUID },
-  'CounterColumnType': { ser:NOOP, de:NOOP },
+  'CounterColumnType': { ser:IDENTITY, de:IDENTITY },
   'FloatType': { ser:Serializers.encodeFloat, de:Deserializers.decodeFloat },
   'DoubleType':{ ser:Serializers.encodeDouble, de:Deserializers.decodeDouble },
   'DecimalType':{ ser:Serializers.encodeDouble, de:Deserializers.decodeDouble },

--- a/lib/row.js
+++ b/lib/row.js
@@ -42,7 +42,7 @@ var Row = function(data, schema){
     //when doing select * you get a column called KEY, it's not good eats.
     if(item.name !== 'KEY'){
       this.push(new Column(name,deserializeValue(item.value), new Date(item.timestamp / 1000), item.ttl));
-      this._map[name] = i;
+      this._map[name] = this.length - 1;
     }
   }
 

--- a/lib/row.js
+++ b/lib/row.js
@@ -62,12 +62,13 @@ util.inherits(Row, Array);
  * @param {ColumnFamily} cf The column family creating the row
  */
 Row.fromThrift = function(key, columns, cf){
-  var data = { columns: [], key:key },
+  var data = { columns: [], key:key }, col,
       schema = {}, i = 0, len = columns.length;
 
-  //TODO: Implement counter and super columns
+  //TODO: Implement super columns
   for(; i < len; i += 1){
-    data.columns.push( columns[i].column );
+    col = cf.isCounter ? columns[i].counter_column : columns[i].column;
+    data.columns.push( col );
   }
 
   schema.value_types = {};

--- a/test/helpers/thrift.json
+++ b/test/helpers/thrift.json
@@ -1,8 +1,9 @@
-{  
+{
   "keyspace"     : "helenus_test_keyspace",
   "cf_standard"  : "cf_standard_test",
   "cf_standard_composite"  : "cf_standard_composite_test",
   "cf_supercolumn"  : "cf_supercolumn_test",
+  "cf_counter"   : "cf_counter_test",
   "cf_invalid"   : "cf_invalid_test",
   "cf_error"     : "<!`~;/?}]|\\-",
   "cf_standard_options"   : {
@@ -31,11 +32,16 @@
     "default_validation_class" : "UTF8Type"
   },
   "cf_supercolumn_options" : {
-    "column_type" : "Super", 
+    "column_type" : "Super",
     "key_validation_class"  : "UTF8Type",
     "default_validation_class" : "UTF8Type",
     "comparator_type" : "UTF8Type",
     "subcomparator_type" : "UTF8Type"
+  },
+  "cf_counter_options" : {
+    "default_validation_class" : "CounterColumnType",
+    "key_validation_class" : "UTF8Type",
+    "comparator_type" : "UTF8Type"
   },
   "standard_row_key" : "standard_row_1",
   "standard_insert_values" : {


### PR DESCRIPTION
Still pretty basic, and I'm happy to take feedback on it. It adds the increment operation to the helenus client for counter columns. 

Unfortunately, it doesn't work with small negative numbers because of the way the node thrift client works. I filed an issue here: https://github.com/simplereach/node-thrift/issues/1
