### PR TITLE
Named params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 *.sock
 lib-cov/
+npm-debug.log

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -57,25 +57,87 @@ function createError(err){
  * Formats CQL properly, paradigm borrowed from node-mysql:
  * https://github.com/felixge/node-mysql/blob/master/lib/client.js#L145-199
  *
- * @param {String} str
+ * `params` is an Array of positional parameters that replace '?', '#', '%s',
+ * '%d' and '%j' with it's values. '#' parameters are double-quoted and all
+ * others are single-quoted. `boolean` and `number` values are not quoted at
+ * all.
+ *
+ * Named parameters is an object that replaces named place holders that begin
+ * with ':'. If the place holder ends with ':', then the value will be wrapped
+ * in single quotes, otherwise it will be wrapped in double quotes. In cql3
+ * values should be single quoted and all other identifiers should be double
+ * quoted. In cql2, everything should be single-quoted. `boolean` and `number`
+ * values are not quoted at all.
+ *
+ * If you only have named_params, you can use it as the second argument.
+ *
+ * Example using named parameters in cql3:
+ *
+ * formatCQL
+ *   ( "SELECT :col1, :col2 FROM :cf WHERE :col1 = :val1: and :col3 = :val3:"
+ *   , { "col1": "name"
+ *     , "col2": "value"
+ *     , "col3": "type"
+ *     , "cf"  : "MyColumnFamily"
+ *     , "val1": "age"
+ *     , "val3": "number" } )
+ *
+ *   > SELECT "name", "value" FROM "MyColumnFamily" WHERE "name" = 'age' AND
+ *                                                        "type" = 'number'
+ *
+ * The same example using positional parameters in cql3::
+ *
+ * formatCQL
+ *   ( "SELECT #, # FROM # WHERE # = ? and # = ?"
+ *   , [ "name"
+ *     , "value"
+ *     , "MyColumnFamily"
+ *     , "name"
+ *     , "age"
+ *     , "type"
+ *     , "number" ] )
+ *
+ * @param {String} cql
+ * @param {Array} params
+ * @param {Object} named_params
  * @private
  * @memberOf Connection
  * @returns {String} The formatted CQL statement
  */
-function formatCQL(cql, params){
+function formatCQL(cql, params, named_params){
+  if (!named_params) {
+    if (!Array.isArray(params)) {
+      named_params = params;
+      params = [];
+    } else {
+      named_params = {};
+    }
+  }
+
   //replace a %% with a % to maintain backward compatibility with util.format
   cql = cql.replace(/%%/, '%');
 
   //remove existing quotes around parameters in case the user has already wrapped them
-  cql = cql.replace(/'(\?|%[sjd])'/g, '$1');
+  cql = cql.replace(/'(#|\?|%[sjd]|:[^\s,]+)'/g, '$1');
 
   //escape the params and format the CQL string
-  cql = cql.replace(/\?|%[sjd]/g, function() {
-    if (params.length === 0) {
-      throw createError(new Error('Too Few Parameters Given'));
-    }
+  cql = cql.replace(/#|\?|%[sjd]|:[^\s,]+/g, function(place) {
+    if (place.match(/^:/)) {
+      var quote = place.match(/:$/) ? "'" : '"';
 
-    return escapeCQL(params.shift());
+      place = place.replace(/:/g, '');
+      if (!named_params.hasOwnProperty(place)) {
+        throw createError(new Error('Named Parameter Missing :'+place));
+      }
+
+      return escapeCQL(named_params[place], quote);
+    } else {
+      if (params.length === 0) {
+        throw createError(new Error('Too Few Parameters Given'));
+      }
+
+      return escapeCQL(params.shift(), place == '#' ? '"' : "'");
+    }
   });
 
   if (params.length) {
@@ -87,12 +149,17 @@ function formatCQL(cql, params){
 
 /**
  * Escapes CQL, adapted from node-mysql
- * @param {String} val The value to be escaped
+ * @param {String} val   The value to be escaped
+ * @param {String} quote The quote character. If unspecified, single-quote
+ *                       will be used.
  * @private
  * @memberOf Connection
  * @returns {String} The sanitized string
  */
-function escapeCQL(val) {
+function escapeCQL(val, quote) {
+  if (quote === undefined || quote === null) {
+    quote = '"';
+  }
   if (val === undefined || val === null) {
     return 'NULL';
   }
@@ -107,7 +174,7 @@ function escapeCQL(val) {
 
   if (Array.isArray(val)) {
     var sanitized = val.map( function( v ) { return escapeCQL( v ); } );
-    return "'" + sanitized.join( "','" ) + "'";
+    return quote + sanitized.join(quote + "," + quote) + quote;
   }
 
   if (typeof val === 'object') {
@@ -116,7 +183,7 @@ function escapeCQL(val) {
 
   val = val.replace(/\'/img, '\'\'');
 
-  return "'"+val+"'";
+  return quote + val + quote;
 }
 
 /**
@@ -378,31 +445,75 @@ Connection.prototype.execute = function(){
 
 /**
  * Executes a CQL Query Against the DB.
+ *
+ * If there is one Object argument, it will be used for options. To use
+ * named_params, you *must* pass a subsequent object for options, even
+ * if it's empty({}).
+ *
+ * See formatCQL for parameter format details.
+ *
  * @param {String} cmd A string representation of the query: 'select %s, %s from MyCf where key=%s'
- * @param {Array} args0...argsN An Array of arguments for the string ['arg0', 'arg1', 'arg2']
+ * @param {Array} params0...paramsN An Array of arguments for the string ['arg0', 'arg1', 'arg2']
+ * @param {Object} named_params An object of named arguments for the string {val0: 'arg0', val1: 'arg1'}
  * @param {Object} options An object with options for the query, { gzip:true }
  * @param {Function} callback The callback function for the results
  */
-Connection.prototype.cql = function(cmd, args, options, callback){
-  //case when only a cmd and callback are supplied
-  if(typeof args === 'function'){
-    callback = args;
-    options = {};
-    args = undefined;
-  }
+Connection.prototype.cql = function() {
+  var args = Array.prototype.slice.apply(arguments);
 
-  //case when cmd args and callback are supplied
-  if (typeof options === 'function' && Array.isArray(args)){
-    callback = options;
-    options = {};
-  }
+  var callback
+    , options
+    , named_params
+    , params
+    , cmd;
 
-  //case when cmd options and callback are supplied, but not args
-  if(typeof options === 'function' && !Array.isArray(args)){
-    callback = options;
-    options = args;
-    args = undefined;
+
+  /**
+   * Parses cql() arguments
+   */
+  function next_arg() {
+    var next = args.pop();
+
+    if (typeof next === 'function') {
+      // callback is the only function argument
+      if (callback) {
+        throw new Error('Mutliple function arguments passed');
+      }
+      callback = next;
+    } else if (Array.isArray(next)) {
+      // params is the only Array argument
+      if (params) {
+        throw new Error('Multiple Array arguments passed');
+      }
+      params = next;
+    } else if (typeof next === 'object') {
+      // named_params and options. If only one object is passed, it will be
+      // options for backward compatibility. If two are passed then the first
+      // is named_params and the second is options.
+      if (!options) {
+        options = next;
+      } else {
+        if (named_params) {
+          throw new Error('More than two object arguments passed');
+        }
+        named_params = next;
+      }
+    } else if (typeof next === 'string') {
+      // cmd is the only string argument
+      if (cmd) {
+        throw new Error('Multiple string arguments passed');
+      }
+      cmd = next;
+    } else {
+      // whoops! What the heck di you pass us?
+      throw new Error('Invalid argument type passed: '+ typeof next);
+    }
+
+    if (args.length > 0) {
+      next_arg();
+    }
   }
+  next_arg();
 
   if(options === undefined || options === null){
     options = {};
@@ -415,8 +526,8 @@ Connection.prototype.cql = function(cmd, args, options, callback){
 
   var cql, escaped = [], self = this;
 
-  if(args){
-    cql = new Buffer(formatCQL(cmd, args));
+  if(params || named_params){
+    cql = new Buffer(formatCQL(cmd, params, named_params));
   } else {
     cql = new Buffer(cmd);
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -181,7 +181,14 @@ function escapeCQL(val, quote) {
     val = (typeof val.toISOString === 'function') ? val.toISOString() : val.toString();
   }
 
-  val = val.replace(/\'/img, '\'\'');
+  if (quote == "'") {
+    val = val.replace(/\'/img, "''");
+  } else {
+    // Protect against injection attacks
+    if (val.indexOf(quote) >= 0) {
+      throw new Error("Illegal quote character in value " + val)
+    }
+  }
 
   return quote + val + quote;
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -118,19 +118,18 @@ function formatCQL(cql, params, named_params){
   cql = cql.replace(/%%/, '%');
 
   //remove existing quotes around parameters in case the user has already wrapped them
-  cql = cql.replace(/'(#|\?|%[sjd]|:[^\s,]+)'/g, '$1');
+  cql = cql.replace(/'(#|\?|%[sjd]|:\w+:?)'/g, '$1');
 
   //escape the params and format the CQL string
-  cql = cql.replace(/#|\?|%[sjd]|:[^\s,]+/g, function(place) {
+  cql = cql.replace(/#|\?|%[sjd]|:\w+:?/g, function(place) {
     if (place.match(/^:/)) {
-      var quote = place.match(/:$/) ? "'" : '"';
 
-      place = place.replace(/:/g, '');
-      if (!named_params.hasOwnProperty(place)) {
-        throw createError(new Error('Named Parameter Missing :'+place));
+      var name = place.replace(/:/g, '');
+      if (!named_params.hasOwnProperty(name)) {
+        throw createError(new Error('Named Parameter Missing '+place));
       }
 
-      return escapeCQL(named_params[place], quote);
+      return escapeCQL(named_params[name], place.match(/:$/) ? "'" : '"');
     } else {
       if (params.length === 0) {
         throw createError(new Error('Too Few Parameters Given'));
@@ -140,7 +139,7 @@ function formatCQL(cql, params, named_params){
     }
   });
 
-  if (params.length) {
+  if (params && params.length) {
     throw createError(new Error('Too Many Parameters Given'));
   }
 
@@ -173,8 +172,8 @@ function escapeCQL(val, quote) {
   }
 
   if (Array.isArray(val)) {
-    var sanitized = val.map( function( v ) { return escapeCQL( v ); } );
-    return quote + sanitized.join(quote + "," + quote) + quote;
+    var sanitized = val.map( function( v ) { return escapeCQL( v, quote ); } );
+    return sanitized.join(quote + "," + quote);
   }
 
   if (typeof val === 'object') {

--- a/test/cql3.js
+++ b/test/cql3.js
@@ -145,6 +145,14 @@ module.exports = {
     assert.strictEqual(res[0].get('url').value, 'www.foo.com');
     assert.strictEqual(res[0].get('ts').value.getTime(), new Date('2012-03-02').getTime());
   }),
+  'test cql dynamic CF by row and column with fields':testCql(config['dynamic_select3#cql'], [], config['dynamic_select3#vals'], {}, function(test, assert, err, res){
+    assert.strictEqual(res.length, 1);
+    assert.ok(res[0] instanceof Helenus.Row);
+    assert.strictEqual(res[0].length, 3);
+    assert.strictEqual(res[0].get('userid').value, 10);
+    assert.strictEqual(res[0].get('url').value, 'www.foo.com');
+    assert.strictEqual(res[0].get('ts').value.getTime(), new Date('2012-03-02').getTime());
+  }),
 
   'test cql dense composite CF create column family':testResultless(config['dense_create_cf#cql']),
   'test cql dense composite CF update 1':testResultless(config['dense_update#cql'], config['dense_update#vals1']),

--- a/test/cql3.js
+++ b/test/cql3.js
@@ -14,7 +14,12 @@ function testCql(){
       tests(test, assert, err, res);
       test.finish();
     });
-    conn.cql.apply(conn, args);
+    try {
+      conn.cql.apply(conn, args);
+    } catch(e) {
+      tests(test, assert, e);
+      test.finish()
+    }
   };
 }
 
@@ -69,10 +74,11 @@ module.exports = {
   }),
 
   'test cql static CF select with bad user input':testCql("SELECT foo FROM cql_test WHERE id='?'", ["'foobar"], function(test, assert, err, res){
-    assert.ok(res.length === 1);
-    assert.ok(res[0] instanceof Helenus.Row);
-    assert.ok(res[0].key === "'foobar");
-    assert.ok(res[0].count === 0);
+    assert.ok(res.length === 0);
+  }),
+
+  'test cql static CF select with bad double-quote user input':testCql("SELECT foo FROM cql_test WHERE id=#", ['"foobar'], function(test, assert, err, res){
+    assert.ok(err.stack);
   }),
 
   'test cql static CF count':testCql(config['static_count#cql'], function(test, assert, err, res){

--- a/test/helpers/cql3.json
+++ b/test/helpers/cql3.json
@@ -20,6 +20,8 @@
   "dynamic_update#vals3"  : ["2012-03-02+0000", 10, "www.foo.com"],
   "dynamic_select1#cql"   : "SELECT ts FROM clicks WHERE userid = '10'",
   "dynamic_select2#cql"   : "SELECT userid, url, ts FROM clicks WHERE userid = 10 AND url = 'www.foo.com'",
+  "dynamic_select3#cql"    : "SELECT :field1, :field2, ts FROM clicks WHERE :field1 = :field1_val: AND :field2 = :field2_val:",
+  "dynamic_select3#vals"   : {"field1": "userid", "field2": "url", "field1_val": 10, "field2_val": "www.foo.com"},
 
   "dense_create_cf#cql" : "CREATE TABLE connections (userid int, ip text, port int, ts timestamp, PRIMARY KEY (userid, ip, port)) WITH COMPACT STORAGE",
   "dense_update#cql"    : "UPDATE connections SET ts = '?' WHERE userid = ? AND ip = '?' AND port = ?",


### PR DESCRIPTION
Spent a few hours on this. My first problem was I'm using cql2, so when I tried some code on cql3 I realized that single-quoting identifiers (column names, column family names, etc.) is no longer valid(bummer). They should be double-quoted or not quoted at all. Since I require this behavior in my client code, I had to add a way to use double-quotes in parameters.

So I added the '#' positional parameter to the existing set, which will be double quoted.

For named parameters, you can use ':<name>' for double-quoted values and ':<name>:' for single-quoted. Everything is backward compatible. The downside of this is that Connection.prototype.cql has to assume that if only one Object argument is passed, it is an options argument. This means that you can't use named parameters without also passing an options argument. Possible ways around this are (1) make a new function, (2) break backward compatibility, (3) accept named parameters in cql() using a single parameter object (optionally), or (4) analyze the cmd to see if it expects named parameters, doing something intelligent.

I didn't realize I'd need the double-quote functionality until after I had already written the named parameter code, so it's all in one commit. I can break it up upon request.
