### PR TITLE
Fix for removing individual composite columns and select * CQL queries

### DIFF
--- a/lib/column_family.js
+++ b/lib/column_family.js
@@ -91,20 +91,17 @@ function columnPath(cf, column, subcolumn) {
  * @returns {Object} a normalized version of the provided parameter values
  */
 function normalizeParameters(list) {
-  var args = { }, i = 0;
+  var args = { }, i = 0, type;
   args.key = list.shift();
   for(; i < list.length; i += 1) {
-    switch(typeof list[i]) {
-      case 'function':
-        args.callback = list[i];
-        break;
-      case 'object':
-        args.options = list[i];
-        break;
-      default:
-        if(i === 0){args.column = list[i];}
-        if(i === 1){args.subcolumn = list[i];}
-        break;
+    type = typeof list[i];
+    if (type === 'function') {
+      args.callback = list[i];
+    } else if (type === 'object' && !Array.isArray(list[i])) {
+      args.options = list[i];
+    } else {
+      if(i === 0){args.column = list[i];}
+      if(i === 1){args.subcolumn = list[i];}
     }
   }
   return args;

--- a/lib/row.js
+++ b/lib/row.js
@@ -42,7 +42,7 @@ var Row = function(data, schema){
     //when doing select * you get a column called KEY, it's not good eats.
     if(item.name !== 'KEY'){
       this.push(new Column(name,deserializeValue(item.value), new Date(item.timestamp / 1000), item.ttl));
-      this._map[name] = i;
+      this._map[name] = this.length - 1;
     }
   }
 


### PR DESCRIPTION
Slight issue with removing a single composite column. The switch statement in `column_family#normalizeParameters` works by the type of each argument. If I pass in an array for the column name, it will delete the entire row instead of just the composite with that name.

I changed the behavior to assume that the argument passed in will be `options` only if it is not an array. Now I am able to remove individual composites in the same way as normal columns

``` javascript
cf.remove(key, ['my', 'composite', 'name'], callback);
```

The other fix is for select \* CQL queries, where if you do something like:

``` javascript

pool.cql('select * from Test', [], function (err, rows) {

  var row = rows[0];
  row['A']; // out of array length since KEY is skipped, but array only has one element

});
```

it breaks because key is skipped. I know there was some discussion and comments about redoing the way this works, but for now it's functionality that I'd like.

Please let me know if there's anything I missed.
