### PR TITLE
Add 'hostPoolSize' option to ConnectionPool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -58,7 +58,7 @@ util.inherits(Pool, process.EventEmitter);
  * @param {Function} callback The callback to invoke when all connections have been made
  */
 Pool.prototype.connect = function(callback){
-  var i = 0, j = 0, finished = 0, client, self = this, len = this.hosts.length,
+  var i = 0, finished = 0, client, self = this, len = this.hosts.length,
       connected = 0, errored;
 
   function onConnect(err, connection, keyspace, host){
@@ -110,7 +110,7 @@ Pool.prototype.connect = function(callback){
   }
 
   for(; i < len; i += 1){
-    for(; j < this.hostPoolSize; j +=1){
+    for(var j=0; j < this.hostPoolSize; j +=1){
         connect(this.hosts[i]);
     }
   }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -20,7 +20,8 @@ var NOOP = function(){};
  *     user       : 'mary',
  *     pass       : 'qwerty',
  *     timeout    : 30000,
- *     cqlVersion : '3.0.0'
+ *     cqlVersion : '3.0.0',
+ *     hostPoolSize : 1
  *   });
  *
  * @constructor
@@ -34,6 +35,7 @@ var Pool = function(options){
   this.password = options.password;
   this.timeout = options.timeout;
   this.cqlVersion = options.cqlVersion;
+  this.hostPoolSize = options.hostPoolSize ? options.hostPoolSize : 1;
   this.retryInterval = null;
   this.closing = false;
 
@@ -56,7 +58,7 @@ util.inherits(Pool, process.EventEmitter);
  * @param {Function} callback The callback to invoke when all connections have been made
  */
 Pool.prototype.connect = function(callback){
-  var i = 0, finished = 0, client, self = this, len = this.hosts.length,
+  var i = 0, j = 0, finished = 0, client, self = this, len = this.hosts.length,
       connected = 0, errored;
 
   function onConnect(err, connection, keyspace, host){
@@ -108,7 +110,9 @@ Pool.prototype.connect = function(callback){
   }
 
   for(; i < len; i += 1){
-    connect(this.hosts[i]);
+    for(; j < this.hostPoolSize; j +=1){
+        connect(this.hosts[i]);
+    }
   }
 };
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -40,7 +40,7 @@ var Pool = function(options){
   this.closing = false;
 
   if(!options.hosts && options.host){
-    this.hosts = [options.hosts];
+    this.hosts = [options.host];
   } else {
     this.hosts = options.hosts;
   }
@@ -58,8 +58,9 @@ util.inherits(Pool, process.EventEmitter);
  * @param {Function} callback The callback to invoke when all connections have been made
  */
 Pool.prototype.connect = function(callback){
-  var i = 0, finished = 0, client, self = this, len = this.hosts.length,
-      connected = 0, errored;
+  var i = 0, finished = 0, self = this, 
+      len = this.hosts.length * this.hostPoolSize,
+      connected = 0;
 
   function onConnect(err, connection, keyspace, host){
     finished += 1;
@@ -69,24 +70,22 @@ Pool.prototype.connect = function(callback){
     } else {
       connected += 1;
       self.clients.push(connection);
-
-      //we only want to callback once, after we get a valid connection
-      if(connected === 1){
-        //set the keyspaces connection to be the pool
-        if(keyspace){
-          keyspace.connection = self;
-        }
-        callback(null, keyspace);
-
-        //now that we have a connection, lets start monitoring
-        self.monitorConnections();
-      }
     }
-
+     
     if(finished === len){
       if(self.clients.length === 0){
         callback(new Error('Could Not Connect To Any Nodes'));
       }
+      
+      //set the keyspaces connection to be the pool
+      if(keyspace){
+        keyspace.connection = self;
+      }
+      //we only want to callback once, after we get the final connection
+      callback(null, keyspace);
+
+      //now that we have a connection, lets start monitoring
+      self.monitorConnections();
     }
   }
 
@@ -109,7 +108,7 @@ Pool.prototype.connect = function(callback){
     });
   }
 
-  for(; i < len; i += 1){
+  for(; i < this.hosts.length; i += 1){
     for(var j=0; j < this.hostPoolSize; j +=1){
         connect(this.hosts[i]);
     }

--- a/test/thriftHostPool.js
+++ b/test/thriftHostPool.js
@@ -1,0 +1,13 @@
+/**
+ * Runs tests defined in thrift.js, but with ConnectionPool 
+ * option hostPoolSize set to 5.
+ */
+var config = require('./helpers/thrift'),
+    system = require('./helpers/connection'),
+    thriftTest = require('./thrift'),
+    Helenus, conn, ks, cf_standard, row_standard, cf_composite, cf_counter;
+
+system.hostPoolSize = 5;
+
+module.exports = thriftTest;
+


### PR DESCRIPTION
Small modification that allows the number connections per cluster host to be increased.  Similar to the node-postgres module, which uses a pool of 10 'parallel' connections to the db, bumpng this number up increased the throughput of our app which was making a lot of asynchronous read requests to the cassandra db.  
