### PR TITLE
Updating thrift options and exposing consistency level

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -93,7 +93,7 @@ If you do not want to use CQL, you can make calls using the thrift driver
 
         //get what we just put in
         //the driver will return a Helenus.Row object just like CQL
-        cf.get('foo', function(err, row){
+        cf.get('foo', {consistency:Helenus.ConsistencyLevel.ONE} function(err, row){
           if(err){
             throw(err);
           }
@@ -201,6 +201,15 @@ Columns are returned as objects with the following structure:
     ttl: 123456        //The ttl (in milliseconds) for the columns
   }
 ```
+
+## ConsistencyLevel
+
+Helenus supports using a custom consistency level. By default, when using the thrift client reads and writes will both use `QUORUM`. When using the thrift driver, you simply pass a custom level in the options:
+
+```javascript
+cf.insert(key, values, {consistency : Helenus.ConsistencyLevel.ANY}, callback);
+```
+
 
 ## Contributors
 

--- a/lib/helenus.js
+++ b/lib/helenus.js
@@ -87,4 +87,11 @@ Helenus.UUID = require('./uuid').UUID;
 Helenus.TimeUUID = require('./uuid').TimeUUID;
 
 
+/**
+ * An object exposed to allow for custom consistency levels.
+ * @see ttypes.ConsistencyLevel
+ */
+Helenus.ConsistencyLevel = require('./cassandra/cassandra_types').ConsistencyLevel;
+
+
 module.exports = Helenus;

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -151,6 +151,14 @@ module.exports = {
     });
   },
 
+  'test standard cf.insert with custom CL':function(test, assert){
+    cf_standard.insert(config.standard_row_key, config.standard_insert_values,
+                      { consistency : Helenus.ConsistencyLevel.ANY }, function(err, results){
+      assert.ifError(err);
+      test.finish();
+    });
+  },
+
   'test standard cf.insert into composite cf':function(test, assert){
     var values = [
       new Helenus.Column([12345678912345, new Date(1326400762701)], 'some value')
@@ -212,6 +220,19 @@ module.exports = {
       assert.ifError(err);
       assert.ok(row instanceof Helenus.Row);
       assert.ok(row.count === 1);
+      assert.ok(row.key === config.standard_row_key);
+      assert.ok(row.get('one').value === 'a');
+
+      test.finish();
+    });
+  },
+
+  'test standard cf.get with custom CL':function(test, assert){
+    cf_standard.get(config.standard_row_key,
+                    { consistency : Helenus.ConsistencyLevel.ONE }, function(err, row){
+
+      assert.ifError(err);
+      assert.ok(row instanceof Helenus.Row);
       assert.ok(row.key === config.standard_row_key);
       assert.ok(row.get('one').value === 'a');
 


### PR DESCRIPTION
I'm using the thrift client and would like to use varying CL's. Hopefully this request should allow me to override the defaults. My other thought is that it could be configurable per connection pool, but that also requires updating the CQL code.
