### PR TITLE
Returning reply not available when no nodes available

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -69,7 +69,7 @@ util.inherits(Pool, process.EventEmitter);
  * @param {Function} callback The callback to invoke when all connections have been made
  */
 Pool.prototype.connect = function(callback){
-  var i = 0, finished = 0, self = this, 
+  var i = 0, finished = 0, self = this,
       len = this.hosts.length * this.hostPoolSize,
       connected = 0;
 
@@ -82,12 +82,12 @@ Pool.prototype.connect = function(callback){
       connected += 1;
       self.clients.push(connection);
     }
-     
+
     if(finished === len){
       if(self.clients.length === 0){
-        replyNotAvailable(callback);
+        return replyNotAvailable(callback);
       }
-      
+
       //set the keyspaces connection to be the pool
       if(keyspace){
         keyspace.connection = self;


### PR DESCRIPTION
Fixes #74 - the final callback should just return rather than continuing to monitor. Maybe just merged oddly.
