### PR TITLE
Fixing double callback/timeout not closed problem

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -69,7 +69,7 @@ util.inherits(Pool, process.EventEmitter);
  * @param {Function} callback The callback to invoke when all connections have been made
  */
 Pool.prototype.connect = function(callback){
-  var i = 0, finished = 0, self = this, 
+  var i = 0, finished = 0, self = this,
       len = this.hosts.length * this.hostPoolSize,
       connected = 0;
 
@@ -82,12 +82,12 @@ Pool.prototype.connect = function(callback){
       connected += 1;
       self.clients.push(connection);
     }
-     
+
     if(finished === len){
       if(self.clients.length === 0){
-        replyNotAvailable(callback);
+        return replyNotAvailable(callback);
       }
-      
+
       //set the keyspaces connection to be the pool
       if(keyspace){
         keyspace.connection = self;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -316,12 +316,17 @@ Pool.prototype.close = function(){
 
   clearInterval(this.retryInterval);
 
+  if (len === 0){
+    this.emit('close');
+  }
+
   function closed(){
     j += 1;
     if(j === len){
       self.emit('close');
     }
   }
+
   for(; i < len; i += 1){
     this.clients[i].on('close', closed);
     this.clients[i].close();

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -84,17 +84,16 @@ Pool.prototype.connect = function(callback){
     }
 
     if(finished === len){
-      if(self.clients.length === 0){
-        return replyNotAvailable(callback);
-      }
-
       //set the keyspaces connection to be the pool
       if(keyspace){
         keyspace.connection = self;
       }
       //we only want to callback once, after we get the final connection
-      callback(null, keyspace);
-
+      if(self.clients.length === 0){
+        replyNotAvailable(callback);
+      } else {
+        callback(null, keyspace);
+      }
       //now that we have a connection, lets start monitoring
       self.monitorConnections();
     }

--- a/test/cql2.js
+++ b/test/cql2.js
@@ -33,6 +33,7 @@ module.exports = {
         assert.isDefined(err);
         badConn.cql(config['create_ks#cql'], function(err, res){
            assert.isDefined(err);
+           badConn.close();
            test.finish();
          });
      });

--- a/test/cql3.js
+++ b/test/cql3.js
@@ -60,6 +60,7 @@ module.exports = {
         assert.isDefined(err);
         badConn.cql(config['create_ks#cql'], function(err, res){
            assert.isDefined(err);
+           badConn.close();
            test.finish();
          });
      });

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -47,6 +47,7 @@ module.exports = {
           assert.isDefined(err);
           badConn.dropKeyspace(config.keyspace, function(err){
             assert.isDefined(err);
+            badConn.close();
             test.finish();
           });
        });


### PR DESCRIPTION
All tests are passing now - fixes #74 . I altered the double callback thing by choosing to callback only once after calling `connect`. 

The tests weren't passing after the merge when I hadn't called `close()` the bad connection.
