### PR TITLE
Add support for negative integers to CQL (at least version 3)

### DIFF
--- a/lib/marshal/deserializers.js
+++ b/lib/marshal/deserializers.js
@@ -7,13 +7,19 @@ var UUID = require('../uuid').UUID,
  */
 var Deserializers = {};
 
-Deserializers.decodeInteger = function(bits, val){
+Deserializers.decodeInteger = function(bits, val, signed){
+  if(signed === null || signed === undefined){
+    signed = false;
+  }
   if(val === null || val === undefined){
     return null;
   }
 
+  //this approach does not work above 32 bits (or perhaps 53)
   var hex = new Buffer(val, 'binary').toString('hex');
-  return parseInt(hex, 16);
+  var x = parseInt(hex, 16);
+  var max = Math.pow( 2, bits );
+  return signed && x >= max / 2 ? x - max : x;
 };
 
 /**
@@ -31,23 +37,68 @@ Deserializers.decodeBinary = function(val){
 };
 
 /**
- * Decodes a Long (UInt64)
+ * Decodes a Long (Int64)
  * @static
  * @param {String} val The binary string to decode
  * @returns {Number} The number value decoded from the binary string
  */
 Deserializers.decodeLong = function(val){
-  return Deserializers.decodeInteger(64, val);
+  if(val === null || val === undefined){
+      return null;
+  }
+
+  var buf = new Buffer(val, 'binary');
+  console.log("parsing 64 bits: " + buf.toString('hex'));
+  var negative = buf.readInt8(0) < 0;
+  if(negative) {
+    //TODO: replace this with a better negative reading function that does up to 53 bytes
+    return buf.readInt32BE(4);    
+  } else {
+    return parseInt(buf.toString('hex'), 16);
+  }
 };
 
 /**
- * Decodes a 32bit Unsinged Integer
+ * Decodes a 32bit signed Integer
  * @param {String} val The binary string to decode
  * @returns {Number} The number value decoded from the binary string
  */
 Deserializers.decodeInt32 = function(val){
-  return Deserializers.decodeInteger(32, val);
+  if(val === null || val === undefined){
+    return null;
+   }
+   console.log("parsing 32 bits: " + new Buffer(val, 'binary').toString('hex'));
+   return new Buffer(val, 'binary').readInt32BE(0, true);
 };
+
+/** 
+ * Decodes a variable length signed integer
+ * @param {String} val The binary string to decode
+ * @returns {Number} The number value decoded from the binary string
+ */
+Deserializers.decodeVarInt  = function(val){
+  if(val === null || val === undefined){
+    return null;
+  }
+  var buf = new Buffer(val, 'binary')
+  switch(buf.length) {
+    case 1:
+      return buf.readInt8(0);
+    case 2:
+      return buf.readInt16BE(0);
+    case 4:
+      return buf.readInt32BE(0);
+    default:
+      var negative = buf.readInt8(0) < 0;
+      if(negative) {
+        //TODO: replace this with a better negative reading function that does up to 53 bytes
+        return buf.readInt32BE(4);
+      } else {
+        return parseInt(buf.toString('hex'), 16);
+      }
+
+  }
+}
 
 /**
  * Decodes for UTF8

--- a/lib/marshal/deserializers.js
+++ b/lib/marshal/deserializers.js
@@ -7,6 +7,16 @@ var UUID = require('../uuid').UUID,
  */
 var Deserializers = {};
 
+var decodeLongFromBuffer = function(buf) {
+    var negative = buf.readInt8(0) < 0;
+    if(negative) {
+      //TODO: replace this with a better negative reading function that does up to 53 bytes
+      return buf.readInt32BE(4);
+    } else {
+      return parseInt(buf.toString('hex'), 16);
+    }
+}
+
 Deserializers.decodeInteger = function(bits, val, signed){
   if(signed === null || signed === undefined){
     signed = false;
@@ -48,14 +58,7 @@ Deserializers.decodeLong = function(val){
   }
 
   var buf = new Buffer(val, 'binary');
-  console.log("parsing 64 bits: " + buf.toString('hex'));
-  var negative = buf.readInt8(0) < 0;
-  if(negative) {
-    //TODO: replace this with a better negative reading function that does up to 53 bytes
-    return buf.readInt32BE(4);    
-  } else {
-    return parseInt(buf.toString('hex'), 16);
-  }
+  return decodeLongFromBuffer(buf);
 };
 
 /**
@@ -67,7 +70,6 @@ Deserializers.decodeInt32 = function(val){
   if(val === null || val === undefined){
     return null;
    }
-   console.log("parsing 32 bits: " + new Buffer(val, 'binary').toString('hex'));
    return new Buffer(val, 'binary').readInt32BE(0, true);
 };
 
@@ -86,17 +88,13 @@ Deserializers.decodeVarInt  = function(val){
       return buf.readInt8(0);
     case 2:
       return buf.readInt16BE(0);
+    //3 is handled by default
     case 4:
       return buf.readInt32BE(0);
+    case 8:
+      return decodeLongFromBuffer(buf);
     default:
-      var negative = buf.readInt8(0) < 0;
-      if(negative) {
-        //TODO: replace this with a better negative reading function that does up to 53 bytes
-        return buf.readInt32BE(4);
-      } else {
-        return parseInt(buf.toString('hex'), 16);
-      }
-
+      return Deserializers.decodeInteger(buf.length*8, val, true);
   }
 }
 

--- a/lib/marshal/index.js
+++ b/lib/marshal/index.js
@@ -24,7 +24,7 @@ var IDENTITY = function (val) { return val; };
 var TYPES = {
   'BytesType': { ser:Serializers.encodeBinary, de:Deserializers.decodeBinary },
   'LongType': { ser:Serializers.encodeLong, de:Deserializers.decodeLong },
-  'IntegerType': { ser:Serializers.encodeInt32, de:Deserializers.decodeInt32 },
+  'IntegerType': { ser:Serializers.encodeInt32, de:Deserializers.decodeVarInt },
   'Int32Type': { ser:Serializers.encodeInt32, de:Deserializers.decodeInt32 },
   'UTF8Type': { ser:Serializers.encodeUTF8, de:Deserializers.decodeUTF8 },
   'AsciiType': { ser:Serializers.encodeAscii, de:Deserializers.decodeAscii },

--- a/test/cql3.js
+++ b/test/cql3.js
@@ -221,6 +221,26 @@ module.exports = {
     assert.strictEqual(res[0].get('body').value, 'body text 1');
     assert.strictEqual(res[0].get('posted_by').value, 'author1');
   }),
+  
+  'test cql integers CF create column family':testResultless(config['integers_create_cf#cql']),
+  'test cql integers CF update 1':testResultless(config['integers_update#cql'], config['integers_update#vals1']),
+  'test cql integers CF update 2':testResultless(config['integers_update#cql'], config['integers_update#vals2']),
+  'test cql integers CF select positive numbers':testCql(config['integers_select1#cql'], function(test, assert, err, res){
+    assert.strictEqual(res.length, 1);
+    assert.ok(res[0] instanceof Helenus.Row);
+    assert.strictEqual(res[0].length, 3);
+    assert.strictEqual(res[0].get('number').value, 1);
+    assert.strictEqual(res[0].get('longnumber').value, 25);
+    assert.strictEqual(res[0].get('varnumber').value, 36);
+  }),
+  'test cql integers CF select negative numbers':testCql(config['integers_select2#cql'], function(test, assert, err, res){
+    assert.strictEqual(res.length, 1);
+    assert.ok(res[0] instanceof Helenus.Row);
+    assert.strictEqual(res[0].length, 3);
+    assert.strictEqual(res[0].get('number').value, -1);
+    assert.strictEqual(res[0].get('longnumber').value, -25);
+    assert.strictEqual(res[0].get('varnumber').value, -36);
+  }),
 
   'test cql drop keyspace':testResultless(config['drop_ks#cql']),
 

--- a/test/cql3.js
+++ b/test/cql3.js
@@ -225,6 +225,7 @@ module.exports = {
   'test cql integers CF create column family':testResultless(config['integers_create_cf#cql']),
   'test cql integers CF update 1':testResultless(config['integers_update#cql'], config['integers_update#vals1']),
   'test cql integers CF update 2':testResultless(config['integers_update#cql'], config['integers_update#vals2']),
+  'test cql integers CF update 3':testResultless(config['integers_update#cql'], config['integers_update#vals3']),
   'test cql integers CF select positive numbers':testCql(config['integers_select1#cql'], function(test, assert, err, res){
     assert.strictEqual(res.length, 1);
     assert.ok(res[0] instanceof Helenus.Row);
@@ -240,6 +241,14 @@ module.exports = {
     assert.strictEqual(res[0].get('number').value, -1);
     assert.strictEqual(res[0].get('longnumber').value, -25);
     assert.strictEqual(res[0].get('varnumber').value, -36);
+  }),
+  'test cql integers CF select negative numbers with 3 byte varint':testCql(config['integers_select3#cql'], function(test, assert, err, res){
+    assert.strictEqual(res.length, 1);
+    assert.ok(res[0] instanceof Helenus.Row);
+    assert.strictEqual(res[0].length, 3);
+    assert.strictEqual(res[0].get('number').value, -2);
+    assert.strictEqual(res[0].get('longnumber').value, -25);
+    assert.strictEqual(res[0].get('varnumber').value, -8388607);//test a 3 byte-long variable integer
   }),
 
   'test cql drop keyspace':testResultless(config['drop_ks#cql']),

--- a/test/helpers/cql3.json
+++ b/test/helpers/cql3.json
@@ -40,6 +40,14 @@
   "sparse_update#vals3"  : ["body text 3", "author3", 10, "2012-03-02 00:00:00+0000"],
   "sparse_select1#cql"   : "SELECT posted_at, body, posted_by FROM timeline WHERE userid = 10 AND posted_at > '2012-03-01 00:00:00+0000'",
   "sparse_select2#cql"   : "SELECT body, posted_by FROM timeline WHERE userid = 10 AND posted_at = '2012-03-01 00:00:00+0000'",
+  
+  "integers_create_cf#cql"    : "CREATE TABLE integers (number int, longnumber bigint, varnumber varint, PRIMARY KEY (number))",
+  "integers_update#cql"       : "UPDATE integers set longnumber = ?, varnumber = ? where number = ?",
+  "integers_update#vals1"     : [25, 36, 1],
+  "integers_update#vals2"     : [-25, -36, -1],  
+  "integers_select1#cql"      : "SELECT * FROM integers where number = 1",
+  "integers_select2#cql"      : "SELECT * FROM integers where number = -1",
+  
 
   "prepare#cql"   : "SELECT * FROM ? WHERE KEY = ?",
   "error#cql"     : "SOME INVALID CQL"

--- a/test/helpers/cql3.json
+++ b/test/helpers/cql3.json
@@ -45,8 +45,10 @@
   "integers_update#cql"       : "UPDATE integers set longnumber = ?, varnumber = ? where number = ?",
   "integers_update#vals1"     : [25, 36, 1],
   "integers_update#vals2"     : [-25, -36, -1],  
+  "integers_update#vals3"     : [-25, -8388607, -2],
   "integers_select1#cql"      : "SELECT * FROM integers where number = 1",
   "integers_select2#cql"      : "SELECT * FROM integers where number = -1",
+  "integers_select3#cql"      : "SELECT * FROM integers where number = -2",
   
 
   "prepare#cql"   : "SELECT * FROM ? WHERE KEY = ?",


### PR DESCRIPTION
According to the CQL datatypes documentation, the types int, bigint and varint refer to signed integers.

Helenus incorrectly interprets them as unsigned integers, at least from CQL.

The first commit contains tests to test number parsing in CQL3. This test fails on negative integers.

The second commit fixes the test.

This works for positive integers up to 53 bits (which is the 64-bit float javascript limit). For negative integers, with this patch the maximum negative value is the most negative 32 bit signed integer. There is room for improvement here, possibly by introducing a big integer library for the long values, or by trying to parse 53-bit negative numbers instead of 32. These limits apply both to bigint/long and varint above 32 bits.
