### PR TITLE
Boolean values need to enclosed in single quotes

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -88,7 +88,7 @@ function escapeCQL(val) {
     return val.toString('hex');
   }
 
-  if(typeof val === 'boolean' || typeof val === 'number'){
+  if(typeof val === 'number'){
     return val.toString();
   }
 
@@ -97,7 +97,7 @@ function escapeCQL(val) {
     return sanitized.join(',');
   }
 
-  if (typeof val === 'object') {
+  if (typeof val === 'object' || typeof val === 'boolean') {
     val = (typeof val.toISOString === 'function') ? val.toISOString() : val.toString();
   }
 


### PR DESCRIPTION
There is an error in C\* documentation about literals in CQL2/3.

Boolean values need to be enclosed in single quotes. It's true for both CQL2 and CQL3.

``` sql
CREATE TABLE users (
    id text,
    name text,
    email text,
    verified boolean,
    PRIMARY KEY (id)
);
```

``` sql
UPDATE users SET verified = true WHERE id = '1';
```

Bad Request: line 1:33 no viable alternative at input 'WHERE'

``` sql
UPDATE users SET verified = 'true' WHERE id = '1';
```

Success.

``` sql
SELECT id, verified FROM users WHERE id = '1';
```

```
 id | verified_email
----+----------------
  3 |           True
```
