### PR TITLE
Adding destroy method to connection pool

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -513,5 +513,14 @@ Connection.prototype.dropKeyspace = function(keyspace, callback){
 Connection.prototype.close = function(){
   this._connection.end();
 };
+
+
+/**
+ * Destroys the connection to the server
+ */
+Connection.prototype.destroy = function() {
+  this._connection.destroy();
+};
+
 //export our client
 module.exports = Connection;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -338,4 +338,34 @@ Pool.prototype.close = function(){
     this.clients[i].close();
   }
 };
+
+
+/**
+ * Destroys all open connections.
+ */
+Pool.prototype.destroy = function(){
+  var self = this, i = 0, j = 0, len = this.clients.length;
+
+  // Make sure no intervals get set
+  self.closing = true;
+
+  clearInterval(this.retryInterval);
+
+  if (len === 0){
+    this.emit('close');
+  }
+
+  function closed(){
+    j += 1;
+    if(j === len){
+      self.emit('close');
+    }
+  }
+
+  for(; i < len; i += 1){
+    this.clients[i].on('close', closed);
+    this.clients[i].destroy();
+  }
+};
+
 module.exports = Pool;

--- a/test/cql2.js
+++ b/test/cql2.js
@@ -25,6 +25,17 @@ module.exports = {
     });
   },
 
+  'test connection.destroy':function(test, assert){
+    var destroyedConn = new Helenus.ConnectionPool(poolConfig);
+    destroyedConn.on('close', function () {
+        test.finish();
+    });
+    destroyedConn.connect(function(err){
+      assert.ifError(err);
+      destroyedConn.destroy();
+    });
+  },
+
   'test a bad connection will return an error':function(test, assert){
      var badConn = new Helenus.ConnectionPool(badConfig);
      // Add error handler to avoid uncaught exception.

--- a/test/cql3.js
+++ b/test/cql3.js
@@ -66,6 +66,17 @@ module.exports = {
      });
   },
 
+  'test connection.destroy':function(test, assert){
+    var destroyedConn = new Helenus.ConnectionPool(poolConfig);
+    destroyedConn.on('close', function () {
+        test.finish();
+    });
+    destroyedConn.connect(function(err){
+      assert.ifError(err);
+      destroyedConn.destroy();
+    });
+  },
+
   'test cql create keyspace':testResultless(config['create_ks#cql']),
   'test cql use keyspace':testResultless(config['use#cql']),
 

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -27,6 +27,19 @@ module.exports = {
     });
   },
 
+  'test pool.destroy without keyspace':function(test, assert){
+    conn = new Helenus.ConnectionPool(system);
+    conn.on('close', function () {
+      test.finish();
+    });
+    assert.doesNotThrow(function(){
+      conn.connect(function(err, keyspace){
+        assert.ifError(err);
+        conn.destroy();
+      });
+    });
+  },
+
   'test pool.connect with keyspace':function(test, assert){
     system.keyspace = 'system';
     conn = new Helenus.ConnectionPool(system);
@@ -695,6 +708,19 @@ module.exports = {
     });
     assert.doesNotThrow(function(){
       conn.close();
+    });
+  },
+
+  'test pool.destroy':function(test, assert){
+    conn = new Helenus.ConnectionPool(system);
+    conn.on('close', function(){
+      test.finish();
+    });
+    assert.doesNotThrow(function() {
+      conn.connect(function (err, keyspace) {
+        assert.ifError(err);
+        conn.destroy();
+      });
     });
   },
 


### PR DESCRIPTION
**Note**: this will only pass when run with the helenus-thrift version I've pull requested: https://github.com/simplereach/node-thrift/pull/6

I've recently been trying to handle connection errors in the case of a node going down in the middle of a write.

Unless I'm missing something, my best course of action is to:
1. listen on pool errors
2. close the current pool
3. try reconnecting

``` javascript
pool.on('error', function () {
  pool.close();
  pool.connect([...]);
});
```

The problem here is that calling `close` on a connection tries to drain all the writes from it by [calling `end` on its internal connection](https://github.com/simplereach/helenus/blob/master/lib/connection.js#L514). See the [net connection .end()](http://nodejs.org/api/net.html#net_socket_end_data_encoding) and the [stream .end()](http://nodejs.org/api/stream.html#stream_stream_end) vs using [destroy](http://nodejs.org/api/stream.html#stream_stream_destroy). This causes all my queued writes to hang for a node that usually isn't coming up anytime soon. The client should be able to choose between discarding those writes for the sake of returning quickly (via `destroy`) or deciding to wait on the queued data (via `close`)

Thoughts?
