### PR TITLE
Fix handling of reversed CFs for thrift users.

### DIFF
--- a/lib/marshal/index.js
+++ b/lib/marshal/index.js
@@ -78,7 +78,7 @@ function getCompositeTypes(str){
       i = 0, ret = [], typeLength = types.length;
 
   for(; i < typeLength; i += 1){
-    ret.push( getType(types[i]) );
+    ret.push( parseTypeString(types[i]) );
   }
 
   return ret;

--- a/lib/marshal/index.js
+++ b/lib/marshal/index.js
@@ -93,7 +93,7 @@ function parseTypeString(type){
   if (type.indexOf('CompositeType') > -1){
     return getCompositeTypes(type);
   } else if(type.indexOf('ReversedType') > -1){
-    return getInnerType(type);
+    return getType(getInnerType(type));
   } else if(type === null || type === undefined) {
     return 'BytesType';
   } else {

--- a/test/helpers/thrift.js
+++ b/test/helpers/thrift.js
@@ -4,6 +4,7 @@ module.exports = {
   "cf_standard_composite"  : "cf_standard_composite_test",
   "cf_supercolumn"  : "cf_supercolumn_test",
   "cf_counter"   : "cf_counter_test",
+  "cf_reversed"   : "cf_reversed_test",
   "cf_invalid"   : "cf_invalid_test",
   "cf_error"     : "<!`~;/?}]|\\-",
   "cf_standard_options"   : {
@@ -42,6 +43,11 @@ module.exports = {
     "default_validation_class" : "CounterColumnType",
     "key_validation_class" : "UTF8Type",
     "comparator_type" : "UTF8Type"
+  },
+  "cf_reversed_options": {
+    "key_validation_class" : "UTF8Type",
+    "default_validation_class" : "UTF8Type",
+    "comparator_type" : "TimeUUIDType(reversed=true)"
   },
   "standard_row_key" : "standard_row_1",
   "standard_insert_values" : {

--- a/test/helpers/thrift.js
+++ b/test/helpers/thrift.js
@@ -5,6 +5,7 @@ module.exports = {
   "cf_supercolumn"  : "cf_supercolumn_test",
   "cf_counter"   : "cf_counter_test",
   "cf_reversed"   : "cf_reversed_test",
+  "cf_composite_nested_reversed"   : "cf_composite_nested_reversed_test",
   "cf_invalid"   : "cf_invalid_test",
   "cf_error"     : "<!`~;/?}]|\\-",
   "cf_standard_options"   : {
@@ -48,6 +49,11 @@ module.exports = {
     "key_validation_class" : "UTF8Type",
     "default_validation_class" : "UTF8Type",
     "comparator_type" : "TimeUUIDType(reversed=true)"
+  },
+  "cf_composite_nested_reversed_options": {
+    "key_validation_class" : "UTF8Type",
+    "default_validation_class" : "UTF8Type",
+    "comparator_type" : "CompositeType(TimeUUIDType(reversed=true),UTF8Type)"
   },
   "standard_row_key" : "standard_row_1",
   "standard_insert_values" : {

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -1,7 +1,8 @@
 var config = require('./helpers/thrift'),
     system = require('./helpers/connection'),
     badSystem = require('./helpers/bad_connection'),
-    Helenus, conn, ks, cf_standard, row_standard, cf_composite, cf_counter, cf_reversed;
+    Helenus, conn, ks, cf_standard, row_standard, cf_composite, cf_counter,
+    cf_reversed, cf_composite_nested_reversed;
 
 module.exports = {
   'setUp':function(test, assert){
@@ -100,6 +101,13 @@ module.exports = {
 
   'test keyspace.createColumFamily reversed':function(test, assert){
     ks.createColumnFamily(config.cf_reversed, config.cf_reversed_options, function(err){
+      assert.ifError(err);
+      test.finish();
+    });
+  },
+
+  'test keyspace.createColumFamily compositeNestedReversed':function(test, assert){
+    ks.createColumnFamily(config.cf_composite_nested_reversed, config.cf_composite_nested_reversed_options, function(err){
       assert.ifError(err);
       test.finish();
     });

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -1,7 +1,7 @@
 var config = require('./helpers/thrift'),
     system = require('./helpers/connection'),
     badSystem = require('./helpers/bad_connection'),
-    Helenus, conn, ks, cf_standard, row_standard, cf_composite, cf_counter;
+    Helenus, conn, ks, cf_standard, row_standard, cf_composite, cf_counter, cf_reversed;
 
 module.exports = {
   'setUp':function(test, assert){
@@ -93,6 +93,13 @@ module.exports = {
 
   'test keyspace.createCounterFamily':function(test, assert){
     ks.createColumnFamily(config.cf_counter, config.cf_counter_options, function(err){
+      assert.ifError(err);
+      test.finish();
+    });
+  },
+
+  'test keyspace.createColumFamily reversed':function(test, assert){
+    ks.createColumnFamily(config.cf_reversed, config.cf_reversed_options, function(err){
       assert.ifError(err);
       test.finish();
     });


### PR DESCRIPTION
This is a fix for reversed types causing crashes when using the thrift interface. The Issue is very similar to # 67 except for thrift instead of  CQL. 

Helenus would crash on the following cf:

```
create column family run_log
  with column_type = 'Standard'
  and comparator = 'ReversedType(org.apache.cassandra.db.marshal.TimeUUIDType)'
  and default_validation_class = 'UTF8Type'
  and key_validation_class = 'UTF8Type'
  and memtable_operations = 0.590625
  and memtable_throughput = 126
  and memtable_flush_after = 1440
  and rows_cached = 0.0
  and row_cache_save_period = 0
  and keys_cached = 200000.0
  and key_cache_save_period = 14400
  and read_repair_chance = 1.0
  and gc_grace = 864000
  and min_compaction_threshold = 4
  and max_compaction_threshold = 32
  and replicate_on_write = true
  and row_cache_provider = 'ConcurrentLinkedHashCacheProvider';
```

with this error:

```
TypeError: Cannot read property 'ser' of undefined
    at getSerializer (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/lib/marshal/index.js:215:48)
    at new Marshal (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/lib/marshal/index.js:254:20)
    at new ColumnFamily (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/lib/column_family.js:186:27)
    at onComplete (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/lib/keyspace.js:87:33)
    at onReturn (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/lib/connection.js:357:7)
    at exports.Connection.connection.addListener.self.transport.receiver.client._reqs.(anonymous function) (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/node_modules/helenus-thrift/lib/thrift/connection.js:80:11)
    at Object.CassandraClient.recv_describe_keyspace (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/lib/cassandra/Cassandra.js:6641:12)
    at exports.Connection (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/node_modules/helenus-thrift/lib/thrift/connection.js:83:37)
    at Socket.TFramedTransport.receiver (/home/psanford/projects/nearbuy/storenet/node/cassandra/node_modules/helenus/node_modules/helenus-thrift/lib/thrift/transport.js:70:9)
    at Socket.EventEmitter.emit (events.js:88:17)
```

This patch makes sure to parse the inner type the same way a normal column type is parsed.
