### PR TITLE
Basic CQL3 Support

### DIFF
--- a/lib/cassandra/Cassandra.js
+++ b/lib/cassandra/Cassandra.js
@@ -3010,6 +3010,234 @@ Cassandra_batch_mutate_result.prototype.write = function(output) {
   return;
 };
 
+var Cassandra_atomic_batch_mutate_args = function(args) {
+  this.mutation_map = null;
+  this.consistency_level = 1;
+  if (args) {
+    if (args.mutation_map !== undefined) {
+      this.mutation_map = args.mutation_map;
+    }
+    if (args.consistency_level !== undefined) {
+      this.consistency_level = args.consistency_level;
+    }
+  }
+};
+Cassandra_atomic_batch_mutate_args.prototype = {};
+Cassandra_atomic_batch_mutate_args.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.MAP) {
+        var _size294 = 0;
+        var _rtmp3298;
+        this.mutation_map = {};
+        var _ktype295 = 0;
+        var _vtype296 = 0;
+        _rtmp3298 = input.readMapBegin();
+        _ktype295 = _rtmp3298.ktype;
+        _vtype296 = _rtmp3298.vtype;
+        _size294 = _rtmp3298.size;
+        for (var _i299 = 0; _i299 < _size294; ++_i299)
+        {
+          var key300 = null;
+          var val301 = null;
+          key300 = input.readString();
+          var _size302 = 0;
+          var _rtmp3306;
+          val301 = {};
+          var _ktype303 = 0;
+          var _vtype304 = 0;
+          _rtmp3306 = input.readMapBegin();
+          _ktype303 = _rtmp3306.ktype;
+          _vtype304 = _rtmp3306.vtype;
+          _size302 = _rtmp3306.size;
+          for (var _i307 = 0; _i307 < _size302; ++_i307)
+          {
+            var key308 = null;
+            var val309 = null;
+            key308 = input.readString();
+            var _size310 = 0;
+            var _rtmp3314;
+            val309 = [];
+            var _etype313 = 0;
+            _rtmp3314 = input.readListBegin();
+            _etype313 = _rtmp3314.etype;
+            _size310 = _rtmp3314.size;
+            for (var _i315 = 0; _i315 < _size310; ++_i315)
+            {
+              var elem316 = null;
+              elem316 = new ttypes.Mutation();
+              elem316.read(input);
+              val309.push(elem316);
+            }
+            input.readListEnd();
+            val301[key308] = val309;
+          }
+          input.readMapEnd();
+          this.mutation_map[key300] = val301;
+        }
+        input.readMapEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I32) {
+        this.consistency_level = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_atomic_batch_mutate_args.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_atomic_batch_mutate_args');
+  if (this.mutation_map) {
+    output.writeFieldBegin('mutation_map', Thrift.Type.MAP, 1);
+    output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.MAP, Thrift.objectLength(this.mutation_map));
+    for (var kiter317 in this.mutation_map)
+    {
+      if (this.mutation_map.hasOwnProperty(kiter317))
+      {
+        var viter318 = this.mutation_map[kiter317];
+        output.writeString(kiter317);
+        output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.LIST, Thrift.objectLength(viter318));
+        for (var kiter319 in viter318)
+        {
+          if (viter318.hasOwnProperty(kiter319))
+          {
+            var viter320 = viter318[kiter319];
+            output.writeString(kiter319);
+            output.writeListBegin(Thrift.Type.STRUCT, viter320.length);
+            for (var iter321 in viter320)
+            {
+              if (viter320.hasOwnProperty(iter321))
+              {
+                iter321 = viter320[iter321];
+                iter321.write(output);
+              }
+            }
+            output.writeListEnd();
+          }
+        }
+        output.writeMapEnd();
+      }
+    }
+    output.writeMapEnd();
+    output.writeFieldEnd();
+  }
+  if (this.consistency_level) {
+    output.writeFieldBegin('consistency_level', Thrift.Type.I32, 2);
+    output.writeI32(this.consistency_level);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_atomic_batch_mutate_result = function(args) {
+  this.ire = null;
+  this.ue = null;
+  this.te = null;
+  if (args) {
+    if (args.ire !== undefined) {
+      this.ire = args.ire;
+    }
+    if (args.ue !== undefined) {
+      this.ue = args.ue;
+    }
+    if (args.te !== undefined) {
+      this.te = args.te;
+    }
+  }
+};
+Cassandra_atomic_batch_mutate_result.prototype = {};
+Cassandra_atomic_batch_mutate_result.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ire = new ttypes.InvalidRequestException();
+        this.ire.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ue = new ttypes.UnavailableException();
+        this.ue.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.te = new ttypes.TimedOutException();
+        this.te.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_atomic_batch_mutate_result.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_atomic_batch_mutate_result');
+  if (this.ire) {
+    output.writeFieldBegin('ire', Thrift.Type.STRUCT, 1);
+    this.ire.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.ue) {
+    output.writeFieldBegin('ue', Thrift.Type.STRUCT, 2);
+    this.ue.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.te) {
+    output.writeFieldBegin('te', Thrift.Type.STRUCT, 3);
+    this.te.write(output);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 var Cassandra_truncate_args = function(args) {
   this.cfname = null;
   if (args) {
@@ -3204,35 +3432,35 @@ Cassandra_describe_schema_versions_result.prototype.read = function(input) {
     {
       case 0:
       if (ftype == Thrift.Type.MAP) {
-        var _size294 = 0;
-        var _rtmp3298;
+        var _size322 = 0;
+        var _rtmp3326;
         this.success = {};
-        var _ktype295 = 0;
-        var _vtype296 = 0;
-        _rtmp3298 = input.readMapBegin();
-        _ktype295 = _rtmp3298.ktype;
-        _vtype296 = _rtmp3298.vtype;
-        _size294 = _rtmp3298.size;
-        for (var _i299 = 0; _i299 < _size294; ++_i299)
+        var _ktype323 = 0;
+        var _vtype324 = 0;
+        _rtmp3326 = input.readMapBegin();
+        _ktype323 = _rtmp3326.ktype;
+        _vtype324 = _rtmp3326.vtype;
+        _size322 = _rtmp3326.size;
+        for (var _i327 = 0; _i327 < _size322; ++_i327)
         {
-          var key300 = null;
-          var val301 = null;
-          key300 = input.readString();
-          var _size302 = 0;
-          var _rtmp3306;
-          val301 = [];
-          var _etype305 = 0;
-          _rtmp3306 = input.readListBegin();
-          _etype305 = _rtmp3306.etype;
-          _size302 = _rtmp3306.size;
-          for (var _i307 = 0; _i307 < _size302; ++_i307)
+          var key328 = null;
+          var val329 = null;
+          key328 = input.readString();
+          var _size330 = 0;
+          var _rtmp3334;
+          val329 = [];
+          var _etype333 = 0;
+          _rtmp3334 = input.readListBegin();
+          _etype333 = _rtmp3334.etype;
+          _size330 = _rtmp3334.size;
+          for (var _i335 = 0; _i335 < _size330; ++_i335)
           {
-            var elem308 = null;
-            elem308 = input.readString();
-            val301.push(elem308);
+            var elem336 = null;
+            elem336 = input.readString();
+            val329.push(elem336);
           }
           input.readListEnd();
-          this.success[key300] = val301;
+          this.success[key328] = val329;
         }
         input.readMapEnd();
       } else {
@@ -3261,19 +3489,19 @@ Cassandra_describe_schema_versions_result.prototype.write = function(output) {
   if (this.success) {
     output.writeFieldBegin('success', Thrift.Type.MAP, 0);
     output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.LIST, Thrift.objectLength(this.success));
-    for (var kiter309 in this.success)
+    for (var kiter337 in this.success)
     {
-      if (this.success.hasOwnProperty(kiter309))
+      if (this.success.hasOwnProperty(kiter337))
       {
-        var viter310 = this.success[kiter309];
-        output.writeString(kiter309);
-        output.writeListBegin(Thrift.Type.STRING, viter310.length);
-        for (var iter311 in viter310)
+        var viter338 = this.success[kiter337];
+        output.writeString(kiter337);
+        output.writeListBegin(Thrift.Type.STRING, viter338.length);
+        for (var iter339 in viter338)
         {
-          if (viter310.hasOwnProperty(iter311))
+          if (viter338.hasOwnProperty(iter339))
           {
-            iter311 = viter310[iter311];
-            output.writeString(iter311);
+            iter339 = viter338[iter339];
+            output.writeString(iter339);
           }
         }
         output.writeListEnd();
@@ -3348,19 +3576,19 @@ Cassandra_describe_keyspaces_result.prototype.read = function(input) {
     {
       case 0:
       if (ftype == Thrift.Type.LIST) {
-        var _size312 = 0;
-        var _rtmp3316;
+        var _size340 = 0;
+        var _rtmp3344;
         this.success = [];
-        var _etype315 = 0;
-        _rtmp3316 = input.readListBegin();
-        _etype315 = _rtmp3316.etype;
-        _size312 = _rtmp3316.size;
-        for (var _i317 = 0; _i317 < _size312; ++_i317)
+        var _etype343 = 0;
+        _rtmp3344 = input.readListBegin();
+        _etype343 = _rtmp3344.etype;
+        _size340 = _rtmp3344.size;
+        for (var _i345 = 0; _i345 < _size340; ++_i345)
         {
-          var elem318 = null;
-          elem318 = new ttypes.KsDef();
-          elem318.read(input);
-          this.success.push(elem318);
+          var elem346 = null;
+          elem346 = new ttypes.KsDef();
+          elem346.read(input);
+          this.success.push(elem346);
         }
         input.readListEnd();
       } else {
@@ -3389,12 +3617,12 @@ Cassandra_describe_keyspaces_result.prototype.write = function(output) {
   if (this.success) {
     output.writeFieldBegin('success', Thrift.Type.LIST, 0);
     output.writeListBegin(Thrift.Type.STRUCT, this.success.length);
-    for (var iter319 in this.success)
+    for (var iter347 in this.success)
     {
-      if (this.success.hasOwnProperty(iter319))
+      if (this.success.hasOwnProperty(iter347))
       {
-        iter319 = this.success[iter319];
-        iter319.write(output);
+        iter347 = this.success[iter347];
+        iter347.write(output);
       }
     }
     output.writeListEnd();
@@ -3653,19 +3881,19 @@ Cassandra_describe_ring_result.prototype.read = function(input) {
     {
       case 0:
       if (ftype == Thrift.Type.LIST) {
-        var _size320 = 0;
-        var _rtmp3324;
+        var _size348 = 0;
+        var _rtmp3352;
         this.success = [];
-        var _etype323 = 0;
-        _rtmp3324 = input.readListBegin();
-        _etype323 = _rtmp3324.etype;
-        _size320 = _rtmp3324.size;
-        for (var _i325 = 0; _i325 < _size320; ++_i325)
+        var _etype351 = 0;
+        _rtmp3352 = input.readListBegin();
+        _etype351 = _rtmp3352.etype;
+        _size348 = _rtmp3352.size;
+        for (var _i353 = 0; _i353 < _size348; ++_i353)
         {
-          var elem326 = null;
-          elem326 = new ttypes.TokenRange();
-          elem326.read(input);
-          this.success.push(elem326);
+          var elem354 = null;
+          elem354 = new ttypes.TokenRange();
+          elem354.read(input);
+          this.success.push(elem354);
         }
         input.readListEnd();
       } else {
@@ -3694,15 +3922,137 @@ Cassandra_describe_ring_result.prototype.write = function(output) {
   if (this.success) {
     output.writeFieldBegin('success', Thrift.Type.LIST, 0);
     output.writeListBegin(Thrift.Type.STRUCT, this.success.length);
-    for (var iter327 in this.success)
+    for (var iter355 in this.success)
     {
-      if (this.success.hasOwnProperty(iter327))
+      if (this.success.hasOwnProperty(iter355))
       {
-        iter327 = this.success[iter327];
-        iter327.write(output);
+        iter355 = this.success[iter355];
+        iter355.write(output);
       }
     }
     output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.ire) {
+    output.writeFieldBegin('ire', Thrift.Type.STRUCT, 1);
+    this.ire.write(output);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_describe_token_map_args = function(args) {
+};
+Cassandra_describe_token_map_args.prototype = {};
+Cassandra_describe_token_map_args.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    input.skip(ftype);
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_describe_token_map_args.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_describe_token_map_args');
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_describe_token_map_result = function(args) {
+  this.success = null;
+  this.ire = null;
+  if (args) {
+    if (args.success !== undefined) {
+      this.success = args.success;
+    }
+    if (args.ire !== undefined) {
+      this.ire = args.ire;
+    }
+  }
+};
+Cassandra_describe_token_map_result.prototype = {};
+Cassandra_describe_token_map_result.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+      if (ftype == Thrift.Type.MAP) {
+        var _size356 = 0;
+        var _rtmp3360;
+        this.success = {};
+        var _ktype357 = 0;
+        var _vtype358 = 0;
+        _rtmp3360 = input.readMapBegin();
+        _ktype357 = _rtmp3360.ktype;
+        _vtype358 = _rtmp3360.vtype;
+        _size356 = _rtmp3360.size;
+        for (var _i361 = 0; _i361 < _size356; ++_i361)
+        {
+          var key362 = null;
+          var val363 = null;
+          key362 = input.readString();
+          val363 = input.readString();
+          this.success[key362] = val363;
+        }
+        input.readMapEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 1:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ire = new ttypes.InvalidRequestException();
+        this.ire.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_describe_token_map_result.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_describe_token_map_result');
+  if (this.success) {
+    output.writeFieldBegin('success', Thrift.Type.MAP, 0);
+    output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.STRING, Thrift.objectLength(this.success));
+    for (var kiter364 in this.success)
+    {
+      if (this.success.hasOwnProperty(kiter364))
+      {
+        var viter365 = this.success[kiter364];
+        output.writeString(kiter364);
+        output.writeString(viter365);
+      }
+    }
+    output.writeMapEnd();
     output.writeFieldEnd();
   }
   if (this.ire) {
@@ -4141,18 +4491,18 @@ Cassandra_describe_splits_result.prototype.read = function(input) {
     {
       case 0:
       if (ftype == Thrift.Type.LIST) {
-        var _size328 = 0;
-        var _rtmp3332;
+        var _size366 = 0;
+        var _rtmp3370;
         this.success = [];
-        var _etype331 = 0;
-        _rtmp3332 = input.readListBegin();
-        _etype331 = _rtmp3332.etype;
-        _size328 = _rtmp3332.size;
-        for (var _i333 = 0; _i333 < _size328; ++_i333)
+        var _etype369 = 0;
+        _rtmp3370 = input.readListBegin();
+        _etype369 = _rtmp3370.etype;
+        _size366 = _rtmp3370.size;
+        for (var _i371 = 0; _i371 < _size366; ++_i371)
         {
-          var elem334 = null;
-          elem334 = input.readString();
-          this.success.push(elem334);
+          var elem372 = null;
+          elem372 = input.readString();
+          this.success.push(elem372);
         }
         input.readListEnd();
       } else {
@@ -4181,12 +4531,281 @@ Cassandra_describe_splits_result.prototype.write = function(output) {
   if (this.success) {
     output.writeFieldBegin('success', Thrift.Type.LIST, 0);
     output.writeListBegin(Thrift.Type.STRING, this.success.length);
-    for (var iter335 in this.success)
+    for (var iter373 in this.success)
     {
-      if (this.success.hasOwnProperty(iter335))
+      if (this.success.hasOwnProperty(iter373))
       {
-        iter335 = this.success[iter335];
-        output.writeString(iter335);
+        iter373 = this.success[iter373];
+        output.writeString(iter373);
+      }
+    }
+    output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.ire) {
+    output.writeFieldBegin('ire', Thrift.Type.STRUCT, 1);
+    this.ire.write(output);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_trace_next_query_args = function(args) {
+};
+Cassandra_trace_next_query_args.prototype = {};
+Cassandra_trace_next_query_args.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    input.skip(ftype);
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_trace_next_query_args.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_trace_next_query_args');
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_trace_next_query_result = function(args) {
+  this.success = null;
+  if (args) {
+    if (args.success !== undefined) {
+      this.success = args.success;
+    }
+  }
+};
+Cassandra_trace_next_query_result.prototype = {};
+Cassandra_trace_next_query_result.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+      if (ftype == Thrift.Type.STRING) {
+        this.success = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 0:
+        input.skip(ftype);
+        break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_trace_next_query_result.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_trace_next_query_result');
+  if (this.success) {
+    output.writeFieldBegin('success', Thrift.Type.STRING, 0);
+    output.writeString(this.success);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_describe_splits_ex_args = function(args) {
+  this.cfName = null;
+  this.start_token = null;
+  this.end_token = null;
+  this.keys_per_split = null;
+  if (args) {
+    if (args.cfName !== undefined) {
+      this.cfName = args.cfName;
+    }
+    if (args.start_token !== undefined) {
+      this.start_token = args.start_token;
+    }
+    if (args.end_token !== undefined) {
+      this.end_token = args.end_token;
+    }
+    if (args.keys_per_split !== undefined) {
+      this.keys_per_split = args.keys_per_split;
+    }
+  }
+};
+Cassandra_describe_splits_ex_args.prototype = {};
+Cassandra_describe_splits_ex_args.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.cfName = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.STRING) {
+        this.start_token = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.STRING) {
+        this.end_token = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 4:
+      if (ftype == Thrift.Type.I32) {
+        this.keys_per_split = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_describe_splits_ex_args.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_describe_splits_ex_args');
+  if (this.cfName) {
+    output.writeFieldBegin('cfName', Thrift.Type.STRING, 1);
+    output.writeString(this.cfName);
+    output.writeFieldEnd();
+  }
+  if (this.start_token) {
+    output.writeFieldBegin('start_token', Thrift.Type.STRING, 2);
+    output.writeString(this.start_token);
+    output.writeFieldEnd();
+  }
+  if (this.end_token) {
+    output.writeFieldBegin('end_token', Thrift.Type.STRING, 3);
+    output.writeString(this.end_token);
+    output.writeFieldEnd();
+  }
+  if (this.keys_per_split) {
+    output.writeFieldBegin('keys_per_split', Thrift.Type.I32, 4);
+    output.writeI32(this.keys_per_split);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_describe_splits_ex_result = function(args) {
+  this.success = null;
+  this.ire = null;
+  if (args) {
+    if (args.success !== undefined) {
+      this.success = args.success;
+    }
+    if (args.ire !== undefined) {
+      this.ire = args.ire;
+    }
+  }
+};
+Cassandra_describe_splits_ex_result.prototype = {};
+Cassandra_describe_splits_ex_result.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+      if (ftype == Thrift.Type.LIST) {
+        var _size374 = 0;
+        var _rtmp3378;
+        this.success = [];
+        var _etype377 = 0;
+        _rtmp3378 = input.readListBegin();
+        _etype377 = _rtmp3378.etype;
+        _size374 = _rtmp3378.size;
+        for (var _i379 = 0; _i379 < _size374; ++_i379)
+        {
+          var elem380 = null;
+          elem380 = new ttypes.CfSplit();
+          elem380.read(input);
+          this.success.push(elem380);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 1:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ire = new ttypes.InvalidRequestException();
+        this.ire.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_describe_splits_ex_result.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_describe_splits_ex_result');
+  if (this.success) {
+    output.writeFieldBegin('success', Thrift.Type.LIST, 0);
+    output.writeListBegin(Thrift.Type.STRUCT, this.success.length);
+    for (var iter381 in this.success)
+    {
+      if (this.success.hasOwnProperty(iter381))
+      {
+        iter381 = this.success[iter381];
+        iter381.write(output);
       }
     }
     output.writeListEnd();
@@ -5213,6 +5832,207 @@ Cassandra_execute_cql_query_result.prototype.write = function(output) {
   return;
 };
 
+var Cassandra_execute_cql3_query_args = function(args) {
+  this.query = null;
+  this.compression = null;
+  this.consistency = null;
+  if (args) {
+    if (args.query !== undefined) {
+      this.query = args.query;
+    }
+    if (args.compression !== undefined) {
+      this.compression = args.compression;
+    }
+    if (args.consistency !== undefined) {
+      this.consistency = args.consistency;
+    }
+  }
+};
+Cassandra_execute_cql3_query_args.prototype = {};
+Cassandra_execute_cql3_query_args.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.query = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I32) {
+        this.compression = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.I32) {
+        this.consistency = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_execute_cql3_query_args.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_execute_cql3_query_args');
+  if (this.query) {
+    output.writeFieldBegin('query', Thrift.Type.STRING, 1);
+    output.writeString(this.query);
+    output.writeFieldEnd();
+  }
+  if (this.compression) {
+    output.writeFieldBegin('compression', Thrift.Type.I32, 2);
+    output.writeI32(this.compression);
+    output.writeFieldEnd();
+  }
+  if (this.consistency) {
+    output.writeFieldBegin('consistency', Thrift.Type.I32, 3);
+    output.writeI32(this.consistency);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_execute_cql3_query_result = function(args) {
+  this.success = null;
+  this.ire = null;
+  this.ue = null;
+  this.te = null;
+  this.sde = null;
+  if (args) {
+    if (args.success !== undefined) {
+      this.success = args.success;
+    }
+    if (args.ire !== undefined) {
+      this.ire = args.ire;
+    }
+    if (args.ue !== undefined) {
+      this.ue = args.ue;
+    }
+    if (args.te !== undefined) {
+      this.te = args.te;
+    }
+    if (args.sde !== undefined) {
+      this.sde = args.sde;
+    }
+  }
+};
+Cassandra_execute_cql3_query_result.prototype = {};
+Cassandra_execute_cql3_query_result.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.success = new ttypes.CqlResult();
+        this.success.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 1:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ire = new ttypes.InvalidRequestException();
+        this.ire.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ue = new ttypes.UnavailableException();
+        this.ue.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.te = new ttypes.TimedOutException();
+        this.te.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 4:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.sde = new ttypes.SchemaDisagreementException();
+        this.sde.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_execute_cql3_query_result.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_execute_cql3_query_result');
+  if (this.success) {
+    output.writeFieldBegin('success', Thrift.Type.STRUCT, 0);
+    this.success.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.ire) {
+    output.writeFieldBegin('ire', Thrift.Type.STRUCT, 1);
+    this.ire.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.ue) {
+    output.writeFieldBegin('ue', Thrift.Type.STRUCT, 2);
+    this.ue.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.te) {
+    output.writeFieldBegin('te', Thrift.Type.STRUCT, 3);
+    this.te.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.sde) {
+    output.writeFieldBegin('sde', Thrift.Type.STRUCT, 4);
+    this.sde.write(output);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 var Cassandra_prepare_cql_query_args = function(args) {
   this.query = null;
   this.compression = null;
@@ -5347,6 +6167,140 @@ Cassandra_prepare_cql_query_result.prototype.write = function(output) {
   return;
 };
 
+var Cassandra_prepare_cql3_query_args = function(args) {
+  this.query = null;
+  this.compression = null;
+  if (args) {
+    if (args.query !== undefined) {
+      this.query = args.query;
+    }
+    if (args.compression !== undefined) {
+      this.compression = args.compression;
+    }
+  }
+};
+Cassandra_prepare_cql3_query_args.prototype = {};
+Cassandra_prepare_cql3_query_args.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.query = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.I32) {
+        this.compression = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_prepare_cql3_query_args.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_prepare_cql3_query_args');
+  if (this.query) {
+    output.writeFieldBegin('query', Thrift.Type.STRING, 1);
+    output.writeString(this.query);
+    output.writeFieldEnd();
+  }
+  if (this.compression) {
+    output.writeFieldBegin('compression', Thrift.Type.I32, 2);
+    output.writeI32(this.compression);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_prepare_cql3_query_result = function(args) {
+  this.success = null;
+  this.ire = null;
+  if (args) {
+    if (args.success !== undefined) {
+      this.success = args.success;
+    }
+    if (args.ire !== undefined) {
+      this.ire = args.ire;
+    }
+  }
+};
+Cassandra_prepare_cql3_query_result.prototype = {};
+Cassandra_prepare_cql3_query_result.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.success = new ttypes.CqlPreparedResult();
+        this.success.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 1:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ire = new ttypes.InvalidRequestException();
+        this.ire.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_prepare_cql3_query_result.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_prepare_cql3_query_result');
+  if (this.success) {
+    output.writeFieldBegin('success', Thrift.Type.STRUCT, 0);
+    this.success.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.ire) {
+    output.writeFieldBegin('ire', Thrift.Type.STRUCT, 1);
+    this.ire.write(output);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
 var Cassandra_execute_prepared_cql_query_args = function(args) {
   this.itemId = null;
   this.values = null;
@@ -5382,18 +6336,18 @@ Cassandra_execute_prepared_cql_query_args.prototype.read = function(input) {
       break;
       case 2:
       if (ftype == Thrift.Type.LIST) {
-        var _size336 = 0;
-        var _rtmp3340;
+        var _size382 = 0;
+        var _rtmp3386;
         this.values = [];
-        var _etype339 = 0;
-        _rtmp3340 = input.readListBegin();
-        _etype339 = _rtmp3340.etype;
-        _size336 = _rtmp3340.size;
-        for (var _i341 = 0; _i341 < _size336; ++_i341)
+        var _etype385 = 0;
+        _rtmp3386 = input.readListBegin();
+        _etype385 = _rtmp3386.etype;
+        _size382 = _rtmp3386.size;
+        for (var _i387 = 0; _i387 < _size382; ++_i387)
         {
-          var elem342 = null;
-          elem342 = input.readString();
-          this.values.push(elem342);
+          var elem388 = null;
+          elem388 = input.readString();
+          this.values.push(elem388);
         }
         input.readListEnd();
       } else {
@@ -5419,12 +6373,12 @@ Cassandra_execute_prepared_cql_query_args.prototype.write = function(output) {
   if (this.values) {
     output.writeFieldBegin('values', Thrift.Type.LIST, 2);
     output.writeListBegin(Thrift.Type.STRING, this.values.length);
-    for (var iter343 in this.values)
+    for (var iter389 in this.values)
     {
-      if (this.values.hasOwnProperty(iter343))
+      if (this.values.hasOwnProperty(iter389))
       {
-        iter343 = this.values[iter343];
-        output.writeString(iter343);
+        iter389 = this.values[iter389];
+        output.writeString(iter389);
       }
     }
     output.writeListEnd();
@@ -5524,6 +6478,229 @@ Cassandra_execute_prepared_cql_query_result.prototype.read = function(input) {
 
 Cassandra_execute_prepared_cql_query_result.prototype.write = function(output) {
   output.writeStructBegin('Cassandra_execute_prepared_cql_query_result');
+  if (this.success) {
+    output.writeFieldBegin('success', Thrift.Type.STRUCT, 0);
+    this.success.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.ire) {
+    output.writeFieldBegin('ire', Thrift.Type.STRUCT, 1);
+    this.ire.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.ue) {
+    output.writeFieldBegin('ue', Thrift.Type.STRUCT, 2);
+    this.ue.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.te) {
+    output.writeFieldBegin('te', Thrift.Type.STRUCT, 3);
+    this.te.write(output);
+    output.writeFieldEnd();
+  }
+  if (this.sde) {
+    output.writeFieldBegin('sde', Thrift.Type.STRUCT, 4);
+    this.sde.write(output);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_execute_prepared_cql3_query_args = function(args) {
+  this.itemId = null;
+  this.values = null;
+  this.consistency = null;
+  if (args) {
+    if (args.itemId !== undefined) {
+      this.itemId = args.itemId;
+    }
+    if (args.values !== undefined) {
+      this.values = args.values;
+    }
+    if (args.consistency !== undefined) {
+      this.consistency = args.consistency;
+    }
+  }
+};
+Cassandra_execute_prepared_cql3_query_args.prototype = {};
+Cassandra_execute_prepared_cql3_query_args.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.I32) {
+        this.itemId = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.LIST) {
+        var _size390 = 0;
+        var _rtmp3394;
+        this.values = [];
+        var _etype393 = 0;
+        _rtmp3394 = input.readListBegin();
+        _etype393 = _rtmp3394.etype;
+        _size390 = _rtmp3394.size;
+        for (var _i395 = 0; _i395 < _size390; ++_i395)
+        {
+          var elem396 = null;
+          elem396 = input.readString();
+          this.values.push(elem396);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.I32) {
+        this.consistency = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_execute_prepared_cql3_query_args.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_execute_prepared_cql3_query_args');
+  if (this.itemId) {
+    output.writeFieldBegin('itemId', Thrift.Type.I32, 1);
+    output.writeI32(this.itemId);
+    output.writeFieldEnd();
+  }
+  if (this.values) {
+    output.writeFieldBegin('values', Thrift.Type.LIST, 2);
+    output.writeListBegin(Thrift.Type.STRING, this.values.length);
+    for (var iter397 in this.values)
+    {
+      if (this.values.hasOwnProperty(iter397))
+      {
+        iter397 = this.values[iter397];
+        output.writeString(iter397);
+      }
+    }
+    output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.consistency) {
+    output.writeFieldBegin('consistency', Thrift.Type.I32, 3);
+    output.writeI32(this.consistency);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+
+var Cassandra_execute_prepared_cql3_query_result = function(args) {
+  this.success = null;
+  this.ire = null;
+  this.ue = null;
+  this.te = null;
+  this.sde = null;
+  if (args) {
+    if (args.success !== undefined) {
+      this.success = args.success;
+    }
+    if (args.ire !== undefined) {
+      this.ire = args.ire;
+    }
+    if (args.ue !== undefined) {
+      this.ue = args.ue;
+    }
+    if (args.te !== undefined) {
+      this.te = args.te;
+    }
+    if (args.sde !== undefined) {
+      this.sde = args.sde;
+    }
+  }
+};
+Cassandra_execute_prepared_cql3_query_result.prototype = {};
+Cassandra_execute_prepared_cql3_query_result.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 0:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.success = new ttypes.CqlResult();
+        this.success.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 1:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ire = new ttypes.InvalidRequestException();
+        this.ire.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.ue = new ttypes.UnavailableException();
+        this.ue.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.te = new ttypes.TimedOutException();
+        this.te.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 4:
+      if (ftype == Thrift.Type.STRUCT) {
+        this.sde = new ttypes.SchemaDisagreementException();
+        this.sde.read(input);
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+Cassandra_execute_prepared_cql3_query_result.prototype.write = function(output) {
+  output.writeStructBegin('Cassandra_execute_prepared_cql3_query_result');
   if (this.success) {
     output.writeFieldBegin('success', Thrift.Type.STRUCT, 0);
     this.success.write(output);
@@ -6321,6 +7498,47 @@ CassandraClient.prototype.recv_batch_mutate = function(input,mtype,rseqid) {
   }
   callback(null)
 };
+CassandraClient.prototype.atomic_batch_mutate = function(mutation_map, consistency_level, callback) {
+  this.seqid += 1;
+  this._reqs[this.seqid] = callback;
+  this.send_atomic_batch_mutate(mutation_map, consistency_level);
+};
+
+CassandraClient.prototype.send_atomic_batch_mutate = function(mutation_map, consistency_level) {
+  var output = new this.pClass(this.output);
+  output.writeMessageBegin('atomic_batch_mutate', Thrift.MessageType.CALL, this.seqid);
+  var args = new Cassandra_atomic_batch_mutate_args();
+  args.mutation_map = mutation_map;
+  args.consistency_level = consistency_level;
+  args.write(output);
+  output.writeMessageEnd();
+  return this.output.flush();
+};
+
+CassandraClient.prototype.recv_atomic_batch_mutate = function(input,mtype,rseqid) {
+  var callback = this._reqs[rseqid] || function() {};
+  delete this._reqs[rseqid];
+  if (mtype == Thrift.MessageType.EXCEPTION) {
+    var x = new Thrift.TApplicationException();
+    x.read(input);
+    input.readMessageEnd();
+    return callback(x);
+  }
+  var result = new Cassandra_atomic_batch_mutate_result();
+  result.read(input);
+  input.readMessageEnd();
+
+  if (null !== result.ire) {
+    return callback(result.ire);
+  }
+  if (null !== result.ue) {
+    return callback(result.ue);
+  }
+  if (null !== result.te) {
+    return callback(result.te);
+  }
+  callback(null)
+};
 CassandraClient.prototype.truncate = function(cfname, callback) {
   this.seqid += 1;
   this._reqs[this.seqid] = callback;
@@ -6536,6 +7754,42 @@ CassandraClient.prototype.recv_describe_ring = function(input,mtype,rseqid) {
   }
   return callback('describe_ring failed: unknown result');
 };
+CassandraClient.prototype.describe_token_map = function(callback) {
+  this.seqid += 1;
+  this._reqs[this.seqid] = callback;
+  this.send_describe_token_map();
+};
+
+CassandraClient.prototype.send_describe_token_map = function() {
+  var output = new this.pClass(this.output);
+  output.writeMessageBegin('describe_token_map', Thrift.MessageType.CALL, this.seqid);
+  var args = new Cassandra_describe_token_map_args();
+  args.write(output);
+  output.writeMessageEnd();
+  return this.output.flush();
+};
+
+CassandraClient.prototype.recv_describe_token_map = function(input,mtype,rseqid) {
+  var callback = this._reqs[rseqid] || function() {};
+  delete this._reqs[rseqid];
+  if (mtype == Thrift.MessageType.EXCEPTION) {
+    var x = new Thrift.TApplicationException();
+    x.read(input);
+    input.readMessageEnd();
+    return callback(x);
+  }
+  var result = new Cassandra_describe_token_map_result();
+  result.read(input);
+  input.readMessageEnd();
+
+  if (null !== result.ire) {
+    return callback(result.ire);
+  }
+  if (null !== result.success) {
+    return callback(null, result.success);
+  }
+  return callback('describe_token_map failed: unknown result');
+};
 CassandraClient.prototype.describe_partitioner = function(callback) {
   this.seqid += 1;
   this._reqs[this.seqid] = callback;
@@ -6681,6 +7935,79 @@ CassandraClient.prototype.recv_describe_splits = function(input,mtype,rseqid) {
     return callback(null, result.success);
   }
   return callback('describe_splits failed: unknown result');
+};
+CassandraClient.prototype.trace_next_query = function(callback) {
+  this.seqid += 1;
+  this._reqs[this.seqid] = callback;
+  this.send_trace_next_query();
+};
+
+CassandraClient.prototype.send_trace_next_query = function() {
+  var output = new this.pClass(this.output);
+  output.writeMessageBegin('trace_next_query', Thrift.MessageType.CALL, this.seqid);
+  var args = new Cassandra_trace_next_query_args();
+  args.write(output);
+  output.writeMessageEnd();
+  return this.output.flush();
+};
+
+CassandraClient.prototype.recv_trace_next_query = function(input,mtype,rseqid) {
+  var callback = this._reqs[rseqid] || function() {};
+  delete this._reqs[rseqid];
+  if (mtype == Thrift.MessageType.EXCEPTION) {
+    var x = new Thrift.TApplicationException();
+    x.read(input);
+    input.readMessageEnd();
+    return callback(x);
+  }
+  var result = new Cassandra_trace_next_query_result();
+  result.read(input);
+  input.readMessageEnd();
+
+  if (null !== result.success) {
+    return callback(null, result.success);
+  }
+  return callback('trace_next_query failed: unknown result');
+};
+CassandraClient.prototype.describe_splits_ex = function(cfName, start_token, end_token, keys_per_split, callback) {
+  this.seqid += 1;
+  this._reqs[this.seqid] = callback;
+  this.send_describe_splits_ex(cfName, start_token, end_token, keys_per_split);
+};
+
+CassandraClient.prototype.send_describe_splits_ex = function(cfName, start_token, end_token, keys_per_split) {
+  var output = new this.pClass(this.output);
+  output.writeMessageBegin('describe_splits_ex', Thrift.MessageType.CALL, this.seqid);
+  var args = new Cassandra_describe_splits_ex_args();
+  args.cfName = cfName;
+  args.start_token = start_token;
+  args.end_token = end_token;
+  args.keys_per_split = keys_per_split;
+  args.write(output);
+  output.writeMessageEnd();
+  return this.output.flush();
+};
+
+CassandraClient.prototype.recv_describe_splits_ex = function(input,mtype,rseqid) {
+  var callback = this._reqs[rseqid] || function() {};
+  delete this._reqs[rseqid];
+  if (mtype == Thrift.MessageType.EXCEPTION) {
+    var x = new Thrift.TApplicationException();
+    x.read(input);
+    input.readMessageEnd();
+    return callback(x);
+  }
+  var result = new Cassandra_describe_splits_ex_result();
+  result.read(input);
+  input.readMessageEnd();
+
+  if (null !== result.ire) {
+    return callback(result.ire);
+  }
+  if (null !== result.success) {
+    return callback(null, result.success);
+  }
+  return callback('describe_splits_ex failed: unknown result');
 };
 CassandraClient.prototype.system_add_column_family = function(cf_def, callback) {
   this.seqid += 1;
@@ -6969,6 +8296,54 @@ CassandraClient.prototype.recv_execute_cql_query = function(input,mtype,rseqid) 
   }
   return callback('execute_cql_query failed: unknown result');
 };
+CassandraClient.prototype.execute_cql3_query = function(query, compression, consistency, callback) {
+  this.seqid += 1;
+  this._reqs[this.seqid] = callback;
+  this.send_execute_cql3_query(query, compression, consistency);
+};
+
+CassandraClient.prototype.send_execute_cql3_query = function(query, compression, consistency) {
+  var output = new this.pClass(this.output);
+  output.writeMessageBegin('execute_cql3_query', Thrift.MessageType.CALL, this.seqid);
+  var args = new Cassandra_execute_cql3_query_args();
+  args.query = query;
+  args.compression = compression;
+  args.consistency = consistency;
+  args.write(output);
+  output.writeMessageEnd();
+  return this.output.flush();
+};
+
+CassandraClient.prototype.recv_execute_cql3_query = function(input,mtype,rseqid) {
+  var callback = this._reqs[rseqid] || function() {};
+  delete this._reqs[rseqid];
+  if (mtype == Thrift.MessageType.EXCEPTION) {
+    var x = new Thrift.TApplicationException();
+    x.read(input);
+    input.readMessageEnd();
+    return callback(x);
+  }
+  var result = new Cassandra_execute_cql3_query_result();
+  result.read(input);
+  input.readMessageEnd();
+
+  if (null !== result.ire) {
+    return callback(result.ire);
+  }
+  if (null !== result.ue) {
+    return callback(result.ue);
+  }
+  if (null !== result.te) {
+    return callback(result.te);
+  }
+  if (null !== result.sde) {
+    return callback(result.sde);
+  }
+  if (null !== result.success) {
+    return callback(null, result.success);
+  }
+  return callback('execute_cql3_query failed: unknown result');
+};
 CassandraClient.prototype.prepare_cql_query = function(query, compression, callback) {
   this.seqid += 1;
   this._reqs[this.seqid] = callback;
@@ -7006,6 +8381,44 @@ CassandraClient.prototype.recv_prepare_cql_query = function(input,mtype,rseqid) 
     return callback(null, result.success);
   }
   return callback('prepare_cql_query failed: unknown result');
+};
+CassandraClient.prototype.prepare_cql3_query = function(query, compression, callback) {
+  this.seqid += 1;
+  this._reqs[this.seqid] = callback;
+  this.send_prepare_cql3_query(query, compression);
+};
+
+CassandraClient.prototype.send_prepare_cql3_query = function(query, compression) {
+  var output = new this.pClass(this.output);
+  output.writeMessageBegin('prepare_cql3_query', Thrift.MessageType.CALL, this.seqid);
+  var args = new Cassandra_prepare_cql3_query_args();
+  args.query = query;
+  args.compression = compression;
+  args.write(output);
+  output.writeMessageEnd();
+  return this.output.flush();
+};
+
+CassandraClient.prototype.recv_prepare_cql3_query = function(input,mtype,rseqid) {
+  var callback = this._reqs[rseqid] || function() {};
+  delete this._reqs[rseqid];
+  if (mtype == Thrift.MessageType.EXCEPTION) {
+    var x = new Thrift.TApplicationException();
+    x.read(input);
+    input.readMessageEnd();
+    return callback(x);
+  }
+  var result = new Cassandra_prepare_cql3_query_result();
+  result.read(input);
+  input.readMessageEnd();
+
+  if (null !== result.ire) {
+    return callback(result.ire);
+  }
+  if (null !== result.success) {
+    return callback(null, result.success);
+  }
+  return callback('prepare_cql3_query failed: unknown result');
 };
 CassandraClient.prototype.execute_prepared_cql_query = function(itemId, values, callback) {
   this.seqid += 1;
@@ -7053,6 +8466,54 @@ CassandraClient.prototype.recv_execute_prepared_cql_query = function(input,mtype
     return callback(null, result.success);
   }
   return callback('execute_prepared_cql_query failed: unknown result');
+};
+CassandraClient.prototype.execute_prepared_cql3_query = function(itemId, values, consistency, callback) {
+  this.seqid += 1;
+  this._reqs[this.seqid] = callback;
+  this.send_execute_prepared_cql3_query(itemId, values, consistency);
+};
+
+CassandraClient.prototype.send_execute_prepared_cql3_query = function(itemId, values, consistency) {
+  var output = new this.pClass(this.output);
+  output.writeMessageBegin('execute_prepared_cql3_query', Thrift.MessageType.CALL, this.seqid);
+  var args = new Cassandra_execute_prepared_cql3_query_args();
+  args.itemId = itemId;
+  args.values = values;
+  args.consistency = consistency;
+  args.write(output);
+  output.writeMessageEnd();
+  return this.output.flush();
+};
+
+CassandraClient.prototype.recv_execute_prepared_cql3_query = function(input,mtype,rseqid) {
+  var callback = this._reqs[rseqid] || function() {};
+  delete this._reqs[rseqid];
+  if (mtype == Thrift.MessageType.EXCEPTION) {
+    var x = new Thrift.TApplicationException();
+    x.read(input);
+    input.readMessageEnd();
+    return callback(x);
+  }
+  var result = new Cassandra_execute_prepared_cql3_query_result();
+  result.read(input);
+  input.readMessageEnd();
+
+  if (null !== result.ire) {
+    return callback(result.ire);
+  }
+  if (null !== result.ue) {
+    return callback(result.ue);
+  }
+  if (null !== result.te) {
+    return callback(result.te);
+  }
+  if (null !== result.sde) {
+    return callback(result.sde);
+  }
+  if (null !== result.success) {
+    return callback(null, result.success);
+  }
+  return callback('execute_prepared_cql3_query failed: unknown result');
 };
 CassandraClient.prototype.set_cql_version = function(version, callback) {
   this.seqid += 1;
@@ -7316,6 +8777,20 @@ CassandraProcessor.prototype.process_batch_mutate = function(seqid, input, outpu
   })
 }
 
+CassandraProcessor.prototype.process_atomic_batch_mutate = function(seqid, input, output) {
+  var args = new Cassandra_atomic_batch_mutate_args();
+  args.read(input);
+  input.readMessageEnd();
+  var result = new Cassandra_atomic_batch_mutate_result();
+  this._handler.atomic_batch_mutate(args.mutation_map, args.consistency_level, function (success) {
+    result.success = success;
+    output.writeMessageBegin("atomic_batch_mutate", Thrift.MessageType.REPLY, seqid);
+    result.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  })
+}
+
 CassandraProcessor.prototype.process_truncate = function(seqid, input, output) {
   var args = new Cassandra_truncate_args();
   args.read(input);
@@ -7400,6 +8875,20 @@ CassandraProcessor.prototype.process_describe_ring = function(seqid, input, outp
   })
 }
 
+CassandraProcessor.prototype.process_describe_token_map = function(seqid, input, output) {
+  var args = new Cassandra_describe_token_map_args();
+  args.read(input);
+  input.readMessageEnd();
+  var result = new Cassandra_describe_token_map_result();
+  this._handler.describe_token_map(function (success) {
+    result.success = success;
+    output.writeMessageBegin("describe_token_map", Thrift.MessageType.REPLY, seqid);
+    result.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  })
+}
+
 CassandraProcessor.prototype.process_describe_partitioner = function(seqid, input, output) {
   var args = new Cassandra_describe_partitioner_args();
   args.read(input);
@@ -7450,6 +8939,34 @@ CassandraProcessor.prototype.process_describe_splits = function(seqid, input, ou
   this._handler.describe_splits(args.cfName, args.start_token, args.end_token, args.keys_per_split, function (success) {
     result.success = success;
     output.writeMessageBegin("describe_splits", Thrift.MessageType.REPLY, seqid);
+    result.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  })
+}
+
+CassandraProcessor.prototype.process_trace_next_query = function(seqid, input, output) {
+  var args = new Cassandra_trace_next_query_args();
+  args.read(input);
+  input.readMessageEnd();
+  var result = new Cassandra_trace_next_query_result();
+  this._handler.trace_next_query(function (success) {
+    result.success = success;
+    output.writeMessageBegin("trace_next_query", Thrift.MessageType.REPLY, seqid);
+    result.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  })
+}
+
+CassandraProcessor.prototype.process_describe_splits_ex = function(seqid, input, output) {
+  var args = new Cassandra_describe_splits_ex_args();
+  args.read(input);
+  input.readMessageEnd();
+  var result = new Cassandra_describe_splits_ex_result();
+  this._handler.describe_splits_ex(args.cfName, args.start_token, args.end_token, args.keys_per_split, function (success) {
+    result.success = success;
+    output.writeMessageBegin("describe_splits_ex", Thrift.MessageType.REPLY, seqid);
     result.write(output);
     output.writeMessageEnd();
     output.flush();
@@ -7554,6 +9071,20 @@ CassandraProcessor.prototype.process_execute_cql_query = function(seqid, input, 
   })
 }
 
+CassandraProcessor.prototype.process_execute_cql3_query = function(seqid, input, output) {
+  var args = new Cassandra_execute_cql3_query_args();
+  args.read(input);
+  input.readMessageEnd();
+  var result = new Cassandra_execute_cql3_query_result();
+  this._handler.execute_cql3_query(args.query, args.compression, args.consistency, function (success) {
+    result.success = success;
+    output.writeMessageBegin("execute_cql3_query", Thrift.MessageType.REPLY, seqid);
+    result.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  })
+}
+
 CassandraProcessor.prototype.process_prepare_cql_query = function(seqid, input, output) {
   var args = new Cassandra_prepare_cql_query_args();
   args.read(input);
@@ -7562,6 +9093,20 @@ CassandraProcessor.prototype.process_prepare_cql_query = function(seqid, input, 
   this._handler.prepare_cql_query(args.query, args.compression, function (success) {
     result.success = success;
     output.writeMessageBegin("prepare_cql_query", Thrift.MessageType.REPLY, seqid);
+    result.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  })
+}
+
+CassandraProcessor.prototype.process_prepare_cql3_query = function(seqid, input, output) {
+  var args = new Cassandra_prepare_cql3_query_args();
+  args.read(input);
+  input.readMessageEnd();
+  var result = new Cassandra_prepare_cql3_query_result();
+  this._handler.prepare_cql3_query(args.query, args.compression, function (success) {
+    result.success = success;
+    output.writeMessageBegin("prepare_cql3_query", Thrift.MessageType.REPLY, seqid);
     result.write(output);
     output.writeMessageEnd();
     output.flush();
@@ -7582,6 +9127,20 @@ CassandraProcessor.prototype.process_execute_prepared_cql_query = function(seqid
   })
 }
 
+CassandraProcessor.prototype.process_execute_prepared_cql3_query = function(seqid, input, output) {
+  var args = new Cassandra_execute_prepared_cql3_query_args();
+  args.read(input);
+  input.readMessageEnd();
+  var result = new Cassandra_execute_prepared_cql3_query_result();
+  this._handler.execute_prepared_cql3_query(args.itemId, args.values, args.consistency, function (success) {
+    result.success = success;
+    output.writeMessageBegin("execute_prepared_cql3_query", Thrift.MessageType.REPLY, seqid);
+    result.write(output);
+    output.writeMessageEnd();
+    output.flush();
+  })
+}
+
 CassandraProcessor.prototype.process_set_cql_version = function(seqid, input, output) {
   var args = new Cassandra_set_cql_version_args();
   args.read(input);
@@ -7595,3 +9154,4 @@ CassandraProcessor.prototype.process_set_cql_version = function(seqid, input, ou
     output.flush();
   })
 }
+

--- a/lib/cassandra/cassandra_types.js
+++ b/lib/cassandra/cassandra_types.js
@@ -24,7 +24,8 @@ ttypes.IndexOperator = {
 };
 ttypes.IndexType = {
 'KEYS' : 0,
-'CUSTOM' : 1
+'CUSTOM' : 1,
+'COMPOSITES' : 2
 };
 ttypes.Compression = {
 'GZIP' : 1,
@@ -35,7 +36,7 @@ ttypes.CqlResultType = {
 'VOID' : 2,
 'INT' : 3
 };
-ttypes.VERSION = '19.29.0';
+ttypes.VERSION = '19.35.0';
 var Column = module.exports.Column = function(args) {
   this.name = null;
   this.value = null;
@@ -601,6 +602,16 @@ UnavailableException.prototype.write = function(output) {
 var TimedOutException = module.exports.TimedOutException = function(args) {
   Thrift.TException.call(this, "TimedOutException")
   this.name = "TimedOutException"
+  this.acknowledged_by = null;
+  this.acknowledged_by_batchlog = null;
+  if (args) {
+    if (args.acknowledged_by !== undefined) {
+      this.acknowledged_by = args.acknowledged_by;
+    }
+    if (args.acknowledged_by_batchlog !== undefined) {
+      this.acknowledged_by_batchlog = args.acknowledged_by_batchlog;
+    }
+  }
 };
 Thrift.inherits(TimedOutException, Thrift.TException);
 TimedOutException.prototype.name = 'TimedOutException';
@@ -615,7 +626,25 @@ TimedOutException.prototype.read = function(input) {
     if (ftype == Thrift.Type.STOP) {
       break;
     }
-    input.skip(ftype);
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.I32) {
+        this.acknowledged_by = input.readI32();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.BOOL) {
+        this.acknowledged_by_batchlog = input.readBool();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
     input.readFieldEnd();
   }
   input.readStructEnd();
@@ -624,6 +653,16 @@ TimedOutException.prototype.read = function(input) {
 
 TimedOutException.prototype.write = function(output) {
   output.writeStructBegin('TimedOutException');
+  if (this.acknowledged_by) {
+    output.writeFieldBegin('acknowledged_by', Thrift.Type.I32, 1);
+    output.writeI32(this.acknowledged_by);
+    output.writeFieldEnd();
+  }
+  if (this.acknowledged_by_batchlog) {
+    output.writeFieldBegin('acknowledged_by_batchlog', Thrift.Type.BOOL, 2);
+    output.writeBool(this.acknowledged_by_batchlog);
+    output.writeFieldEnd();
+  }
   output.writeFieldStop();
   output.writeStructEnd();
   return;
@@ -2244,7 +2283,7 @@ var CfDef = module.exports.CfDef = function(args) {
   this.comparator_type = 'BytesType';
   this.subcomparator_type = null;
   this.comment = null;
-  this.read_repair_chance = 1;
+  this.read_repair_chance = null;
   this.column_metadata = null;
   this.gc_grace_seconds = null;
   this.default_validation_class = null;
@@ -2259,8 +2298,6 @@ var CfDef = module.exports.CfDef = function(args) {
   this.compression_options = null;
   this.bloom_filter_fp_chance = null;
   this.caching = 'keys_only';
-  this.column_aliases = null;
-  this.value_alias = null;
   this.dclocal_read_repair_chance = 0;
   this.row_cache_size = null;
   this.key_cache_size = null;
@@ -2335,12 +2372,6 @@ var CfDef = module.exports.CfDef = function(args) {
     }
     if (args.caching !== undefined) {
       this.caching = args.caching;
-    }
-    if (args.column_aliases !== undefined) {
-      this.column_aliases = args.column_aliases;
-    }
-    if (args.value_alias !== undefined) {
-      this.value_alias = args.value_alias;
     }
     if (args.dclocal_read_repair_chance !== undefined) {
       this.dclocal_read_repair_chance = args.dclocal_read_repair_chance;
@@ -2586,33 +2617,6 @@ CfDef.prototype.read = function(input) {
         input.skip(ftype);
       }
       break;
-      case 35:
-      if (ftype == Thrift.Type.LIST) {
-        var _size115 = 0;
-        var _rtmp3119;
-        this.column_aliases = [];
-        var _etype118 = 0;
-        _rtmp3119 = input.readListBegin();
-        _etype118 = _rtmp3119.etype;
-        _size115 = _rtmp3119.size;
-        for (var _i120 = 0; _i120 < _size115; ++_i120)
-        {
-          var elem121 = null;
-          elem121 = input.readString();
-          this.column_aliases.push(elem121);
-        }
-        input.readListEnd();
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      case 36:
-      if (ftype == Thrift.Type.STRING) {
-        this.value_alias = input.readString();
-      } else {
-        input.skip(ftype);
-      }
-      break;
       case 37:
       if (ftype == Thrift.Type.DOUBLE) {
         this.dclocal_read_repair_chance = input.readDouble();
@@ -2739,12 +2743,12 @@ CfDef.prototype.write = function(output) {
   if (this.column_metadata) {
     output.writeFieldBegin('column_metadata', Thrift.Type.LIST, 13);
     output.writeListBegin(Thrift.Type.STRUCT, this.column_metadata.length);
-    for (var iter122 in this.column_metadata)
+    for (var iter115 in this.column_metadata)
     {
-      if (this.column_metadata.hasOwnProperty(iter122))
+      if (this.column_metadata.hasOwnProperty(iter115))
       {
-        iter122 = this.column_metadata[iter122];
-        iter122.write(output);
+        iter115 = this.column_metadata[iter115];
+        iter115.write(output);
       }
     }
     output.writeListEnd();
@@ -2798,13 +2802,13 @@ CfDef.prototype.write = function(output) {
   if (this.compaction_strategy_options) {
     output.writeFieldBegin('compaction_strategy_options', Thrift.Type.MAP, 30);
     output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.STRING, Thrift.objectLength(this.compaction_strategy_options));
-    for (var kiter123 in this.compaction_strategy_options)
+    for (var kiter116 in this.compaction_strategy_options)
     {
-      if (this.compaction_strategy_options.hasOwnProperty(kiter123))
+      if (this.compaction_strategy_options.hasOwnProperty(kiter116))
       {
-        var viter124 = this.compaction_strategy_options[kiter123];
-        output.writeString(kiter123);
-        output.writeString(viter124);
+        var viter117 = this.compaction_strategy_options[kiter116];
+        output.writeString(kiter116);
+        output.writeString(viter117);
       }
     }
     output.writeMapEnd();
@@ -2813,13 +2817,13 @@ CfDef.prototype.write = function(output) {
   if (this.compression_options) {
     output.writeFieldBegin('compression_options', Thrift.Type.MAP, 32);
     output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.STRING, Thrift.objectLength(this.compression_options));
-    for (var kiter125 in this.compression_options)
+    for (var kiter118 in this.compression_options)
     {
-      if (this.compression_options.hasOwnProperty(kiter125))
+      if (this.compression_options.hasOwnProperty(kiter118))
       {
-        var viter126 = this.compression_options[kiter125];
-        output.writeString(kiter125);
-        output.writeString(viter126);
+        var viter119 = this.compression_options[kiter118];
+        output.writeString(kiter118);
+        output.writeString(viter119);
       }
     }
     output.writeMapEnd();
@@ -2833,25 +2837,6 @@ CfDef.prototype.write = function(output) {
   if (this.caching) {
     output.writeFieldBegin('caching', Thrift.Type.STRING, 34);
     output.writeString(this.caching);
-    output.writeFieldEnd();
-  }
-  if (this.column_aliases) {
-    output.writeFieldBegin('column_aliases', Thrift.Type.LIST, 35);
-    output.writeListBegin(Thrift.Type.STRING, this.column_aliases.length);
-    for (var iter127 in this.column_aliases)
-    {
-      if (this.column_aliases.hasOwnProperty(iter127))
-      {
-        iter127 = this.column_aliases[iter127];
-        output.writeString(iter127);
-      }
-    }
-    output.writeListEnd();
-    output.writeFieldEnd();
-  }
-  if (this.value_alias) {
-    output.writeFieldBegin('value_alias', Thrift.Type.STRING, 36);
-    output.writeString(this.value_alias);
     output.writeFieldEnd();
   }
   if (this.dclocal_read_repair_chance) {
@@ -2972,22 +2957,22 @@ KsDef.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.MAP) {
-        var _size128 = 0;
-        var _rtmp3132;
+        var _size120 = 0;
+        var _rtmp3124;
         this.strategy_options = {};
-        var _ktype129 = 0;
-        var _vtype130 = 0;
-        _rtmp3132 = input.readMapBegin();
-        _ktype129 = _rtmp3132.ktype;
-        _vtype130 = _rtmp3132.vtype;
-        _size128 = _rtmp3132.size;
-        for (var _i133 = 0; _i133 < _size128; ++_i133)
+        var _ktype121 = 0;
+        var _vtype122 = 0;
+        _rtmp3124 = input.readMapBegin();
+        _ktype121 = _rtmp3124.ktype;
+        _vtype122 = _rtmp3124.vtype;
+        _size120 = _rtmp3124.size;
+        for (var _i125 = 0; _i125 < _size120; ++_i125)
         {
-          var key134 = null;
-          var val135 = null;
-          key134 = input.readString();
-          val135 = input.readString();
-          this.strategy_options[key134] = val135;
+          var key126 = null;
+          var val127 = null;
+          key126 = input.readString();
+          val127 = input.readString();
+          this.strategy_options[key126] = val127;
         }
         input.readMapEnd();
       } else {
@@ -3003,19 +2988,19 @@ KsDef.prototype.read = function(input) {
       break;
       case 5:
       if (ftype == Thrift.Type.LIST) {
-        var _size136 = 0;
-        var _rtmp3140;
+        var _size128 = 0;
+        var _rtmp3132;
         this.cf_defs = [];
-        var _etype139 = 0;
-        _rtmp3140 = input.readListBegin();
-        _etype139 = _rtmp3140.etype;
-        _size136 = _rtmp3140.size;
-        for (var _i141 = 0; _i141 < _size136; ++_i141)
+        var _etype131 = 0;
+        _rtmp3132 = input.readListBegin();
+        _etype131 = _rtmp3132.etype;
+        _size128 = _rtmp3132.size;
+        for (var _i133 = 0; _i133 < _size128; ++_i133)
         {
-          var elem142 = null;
-          elem142 = new ttypes.CfDef();
-          elem142.read(input);
-          this.cf_defs.push(elem142);
+          var elem134 = null;
+          elem134 = new ttypes.CfDef();
+          elem134.read(input);
+          this.cf_defs.push(elem134);
         }
         input.readListEnd();
       } else {
@@ -3053,13 +3038,13 @@ KsDef.prototype.write = function(output) {
   if (this.strategy_options) {
     output.writeFieldBegin('strategy_options', Thrift.Type.MAP, 3);
     output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.STRING, Thrift.objectLength(this.strategy_options));
-    for (var kiter143 in this.strategy_options)
+    for (var kiter135 in this.strategy_options)
     {
-      if (this.strategy_options.hasOwnProperty(kiter143))
+      if (this.strategy_options.hasOwnProperty(kiter135))
       {
-        var viter144 = this.strategy_options[kiter143];
-        output.writeString(kiter143);
-        output.writeString(viter144);
+        var viter136 = this.strategy_options[kiter135];
+        output.writeString(kiter135);
+        output.writeString(viter136);
       }
     }
     output.writeMapEnd();
@@ -3073,12 +3058,12 @@ KsDef.prototype.write = function(output) {
   if (this.cf_defs) {
     output.writeFieldBegin('cf_defs', Thrift.Type.LIST, 5);
     output.writeListBegin(Thrift.Type.STRUCT, this.cf_defs.length);
-    for (var iter145 in this.cf_defs)
+    for (var iter137 in this.cf_defs)
     {
-      if (this.cf_defs.hasOwnProperty(iter145))
+      if (this.cf_defs.hasOwnProperty(iter137))
       {
-        iter145 = this.cf_defs[iter145];
-        iter145.write(output);
+        iter137 = this.cf_defs[iter137];
+        iter137.write(output);
       }
     }
     output.writeListEnd();
@@ -3129,19 +3114,19 @@ CqlRow.prototype.read = function(input) {
       break;
       case 2:
       if (ftype == Thrift.Type.LIST) {
-        var _size146 = 0;
-        var _rtmp3150;
+        var _size138 = 0;
+        var _rtmp3142;
         this.columns = [];
-        var _etype149 = 0;
-        _rtmp3150 = input.readListBegin();
-        _etype149 = _rtmp3150.etype;
-        _size146 = _rtmp3150.size;
-        for (var _i151 = 0; _i151 < _size146; ++_i151)
+        var _etype141 = 0;
+        _rtmp3142 = input.readListBegin();
+        _etype141 = _rtmp3142.etype;
+        _size138 = _rtmp3142.size;
+        for (var _i143 = 0; _i143 < _size138; ++_i143)
         {
-          var elem152 = null;
-          elem152 = new ttypes.Column();
-          elem152.read(input);
-          this.columns.push(elem152);
+          var elem144 = null;
+          elem144 = new ttypes.Column();
+          elem144.read(input);
+          this.columns.push(elem144);
         }
         input.readListEnd();
       } else {
@@ -3167,12 +3152,12 @@ CqlRow.prototype.write = function(output) {
   if (this.columns) {
     output.writeFieldBegin('columns', Thrift.Type.LIST, 2);
     output.writeListBegin(Thrift.Type.STRUCT, this.columns.length);
-    for (var iter153 in this.columns)
+    for (var iter145 in this.columns)
     {
-      if (this.columns.hasOwnProperty(iter153))
+      if (this.columns.hasOwnProperty(iter145))
       {
-        iter153 = this.columns[iter153];
-        iter153.write(output);
+        iter145 = this.columns[iter145];
+        iter145.write(output);
       }
     }
     output.writeListEnd();
@@ -3219,9 +3204,33 @@ CqlMetadata.prototype.read = function(input) {
     {
       case 1:
       if (ftype == Thrift.Type.MAP) {
+        var _size146 = 0;
+        var _rtmp3150;
+        this.name_types = {};
+        var _ktype147 = 0;
+        var _vtype148 = 0;
+        _rtmp3150 = input.readMapBegin();
+        _ktype147 = _rtmp3150.ktype;
+        _vtype148 = _rtmp3150.vtype;
+        _size146 = _rtmp3150.size;
+        for (var _i151 = 0; _i151 < _size146; ++_i151)
+        {
+          var key152 = null;
+          var val153 = null;
+          key152 = input.readString();
+          val153 = input.readString();
+          this.name_types[key152] = val153;
+        }
+        input.readMapEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.MAP) {
         var _size154 = 0;
         var _rtmp3158;
-        this.name_types = {};
+        this.value_types = {};
         var _ktype155 = 0;
         var _vtype156 = 0;
         _rtmp3158 = input.readMapBegin();
@@ -3234,31 +3243,7 @@ CqlMetadata.prototype.read = function(input) {
           var val161 = null;
           key160 = input.readString();
           val161 = input.readString();
-          this.name_types[key160] = val161;
-        }
-        input.readMapEnd();
-      } else {
-        input.skip(ftype);
-      }
-      break;
-      case 2:
-      if (ftype == Thrift.Type.MAP) {
-        var _size162 = 0;
-        var _rtmp3166;
-        this.value_types = {};
-        var _ktype163 = 0;
-        var _vtype164 = 0;
-        _rtmp3166 = input.readMapBegin();
-        _ktype163 = _rtmp3166.ktype;
-        _vtype164 = _rtmp3166.vtype;
-        _size162 = _rtmp3166.size;
-        for (var _i167 = 0; _i167 < _size162; ++_i167)
-        {
-          var key168 = null;
-          var val169 = null;
-          key168 = input.readString();
-          val169 = input.readString();
-          this.value_types[key168] = val169;
+          this.value_types[key160] = val161;
         }
         input.readMapEnd();
       } else {
@@ -3293,13 +3278,13 @@ CqlMetadata.prototype.write = function(output) {
   if (this.name_types) {
     output.writeFieldBegin('name_types', Thrift.Type.MAP, 1);
     output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.STRING, Thrift.objectLength(this.name_types));
-    for (var kiter170 in this.name_types)
+    for (var kiter162 in this.name_types)
     {
-      if (this.name_types.hasOwnProperty(kiter170))
+      if (this.name_types.hasOwnProperty(kiter162))
       {
-        var viter171 = this.name_types[kiter170];
-        output.writeString(kiter170);
-        output.writeString(viter171);
+        var viter163 = this.name_types[kiter162];
+        output.writeString(kiter162);
+        output.writeString(viter163);
       }
     }
     output.writeMapEnd();
@@ -3308,13 +3293,13 @@ CqlMetadata.prototype.write = function(output) {
   if (this.value_types) {
     output.writeFieldBegin('value_types', Thrift.Type.MAP, 2);
     output.writeMapBegin(Thrift.Type.STRING, Thrift.Type.STRING, Thrift.objectLength(this.value_types));
-    for (var kiter172 in this.value_types)
+    for (var kiter164 in this.value_types)
     {
-      if (this.value_types.hasOwnProperty(kiter172))
+      if (this.value_types.hasOwnProperty(kiter164))
       {
-        var viter173 = this.value_types[kiter172];
-        output.writeString(kiter172);
-        output.writeString(viter173);
+        var viter165 = this.value_types[kiter164];
+        output.writeString(kiter164);
+        output.writeString(viter165);
       }
     }
     output.writeMapEnd();
@@ -3378,19 +3363,19 @@ CqlResult.prototype.read = function(input) {
       break;
       case 2:
       if (ftype == Thrift.Type.LIST) {
-        var _size174 = 0;
-        var _rtmp3178;
+        var _size166 = 0;
+        var _rtmp3170;
         this.rows = [];
-        var _etype177 = 0;
-        _rtmp3178 = input.readListBegin();
-        _etype177 = _rtmp3178.etype;
-        _size174 = _rtmp3178.size;
-        for (var _i179 = 0; _i179 < _size174; ++_i179)
+        var _etype169 = 0;
+        _rtmp3170 = input.readListBegin();
+        _etype169 = _rtmp3170.etype;
+        _size166 = _rtmp3170.size;
+        for (var _i171 = 0; _i171 < _size166; ++_i171)
         {
-          var elem180 = null;
-          elem180 = new ttypes.CqlRow();
-          elem180.read(input);
-          this.rows.push(elem180);
+          var elem172 = null;
+          elem172 = new ttypes.CqlRow();
+          elem172.read(input);
+          this.rows.push(elem172);
         }
         input.readListEnd();
       } else {
@@ -3431,12 +3416,12 @@ CqlResult.prototype.write = function(output) {
   if (this.rows) {
     output.writeFieldBegin('rows', Thrift.Type.LIST, 2);
     output.writeListBegin(Thrift.Type.STRUCT, this.rows.length);
-    for (var iter181 in this.rows)
+    for (var iter173 in this.rows)
     {
-      if (this.rows.hasOwnProperty(iter181))
+      if (this.rows.hasOwnProperty(iter173))
       {
-        iter181 = this.rows[iter181];
-        iter181.write(output);
+        iter173 = this.rows[iter173];
+        iter173.write(output);
       }
     }
     output.writeListEnd();
@@ -3461,6 +3446,7 @@ var CqlPreparedResult = module.exports.CqlPreparedResult = function(args) {
   this.itemId = null;
   this.count = null;
   this.variable_types = null;
+  this.variable_names = null;
   if (args) {
     if (args.itemId !== undefined) {
       this.itemId = args.itemId;
@@ -3470,6 +3456,9 @@ var CqlPreparedResult = module.exports.CqlPreparedResult = function(args) {
     }
     if (args.variable_types !== undefined) {
       this.variable_types = args.variable_types;
+    }
+    if (args.variable_names !== undefined) {
+      this.variable_names = args.variable_names;
     }
   }
 };
@@ -3503,18 +3492,38 @@ CqlPreparedResult.prototype.read = function(input) {
       break;
       case 3:
       if (ftype == Thrift.Type.LIST) {
-        var _size182 = 0;
-        var _rtmp3186;
+        var _size174 = 0;
+        var _rtmp3178;
         this.variable_types = [];
-        var _etype185 = 0;
-        _rtmp3186 = input.readListBegin();
-        _etype185 = _rtmp3186.etype;
-        _size182 = _rtmp3186.size;
-        for (var _i187 = 0; _i187 < _size182; ++_i187)
+        var _etype177 = 0;
+        _rtmp3178 = input.readListBegin();
+        _etype177 = _rtmp3178.etype;
+        _size174 = _rtmp3178.size;
+        for (var _i179 = 0; _i179 < _size174; ++_i179)
         {
-          var elem188 = null;
-          elem188 = input.readString();
-          this.variable_types.push(elem188);
+          var elem180 = null;
+          elem180 = input.readString();
+          this.variable_types.push(elem180);
+        }
+        input.readListEnd();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 4:
+      if (ftype == Thrift.Type.LIST) {
+        var _size181 = 0;
+        var _rtmp3185;
+        this.variable_names = [];
+        var _etype184 = 0;
+        _rtmp3185 = input.readListBegin();
+        _etype184 = _rtmp3185.etype;
+        _size181 = _rtmp3185.size;
+        for (var _i186 = 0; _i186 < _size181; ++_i186)
+        {
+          var elem187 = null;
+          elem187 = input.readString();
+          this.variable_names.push(elem187);
         }
         input.readListEnd();
       } else {
@@ -3545,11 +3554,25 @@ CqlPreparedResult.prototype.write = function(output) {
   if (this.variable_types) {
     output.writeFieldBegin('variable_types', Thrift.Type.LIST, 3);
     output.writeListBegin(Thrift.Type.STRING, this.variable_types.length);
-    for (var iter189 in this.variable_types)
+    for (var iter188 in this.variable_types)
     {
-      if (this.variable_types.hasOwnProperty(iter189))
+      if (this.variable_types.hasOwnProperty(iter188))
       {
-        iter189 = this.variable_types[iter189];
+        iter188 = this.variable_types[iter188];
+        output.writeString(iter188);
+      }
+    }
+    output.writeListEnd();
+    output.writeFieldEnd();
+  }
+  if (this.variable_names) {
+    output.writeFieldBegin('variable_names', Thrift.Type.LIST, 4);
+    output.writeListBegin(Thrift.Type.STRING, this.variable_names.length);
+    for (var iter189 in this.variable_names)
+    {
+      if (this.variable_names.hasOwnProperty(iter189))
+      {
+        iter189 = this.variable_names[iter189];
         output.writeString(iter189);
       }
     }
@@ -3560,3 +3583,86 @@ CqlPreparedResult.prototype.write = function(output) {
   output.writeStructEnd();
   return;
 };
+
+var CfSplit = module.exports.CfSplit = function(args) {
+  this.start_token = null;
+  this.end_token = null;
+  this.row_count = null;
+  if (args) {
+    if (args.start_token !== undefined) {
+      this.start_token = args.start_token;
+    }
+    if (args.end_token !== undefined) {
+      this.end_token = args.end_token;
+    }
+    if (args.row_count !== undefined) {
+      this.row_count = args.row_count;
+    }
+  }
+};
+CfSplit.prototype = {};
+CfSplit.prototype.read = function(input) {
+  input.readStructBegin();
+  while (true)
+  {
+    var ret = input.readFieldBegin();
+    var fname = ret.fname;
+    var ftype = ret.ftype;
+    var fid = ret.fid;
+    if (ftype == Thrift.Type.STOP) {
+      break;
+    }
+    switch (fid)
+    {
+      case 1:
+      if (ftype == Thrift.Type.STRING) {
+        this.start_token = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 2:
+      if (ftype == Thrift.Type.STRING) {
+        this.end_token = input.readString();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      case 3:
+      if (ftype == Thrift.Type.I64) {
+        this.row_count = input.readI64();
+      } else {
+        input.skip(ftype);
+      }
+      break;
+      default:
+        input.skip(ftype);
+    }
+    input.readFieldEnd();
+  }
+  input.readStructEnd();
+  return;
+};
+
+CfSplit.prototype.write = function(output) {
+  output.writeStructBegin('CfSplit');
+  if (this.start_token) {
+    output.writeFieldBegin('start_token', Thrift.Type.STRING, 1);
+    output.writeString(this.start_token);
+    output.writeFieldEnd();
+  }
+  if (this.end_token) {
+    output.writeFieldBegin('end_token', Thrift.Type.STRING, 2);
+    output.writeString(this.end_token);
+    output.writeFieldEnd();
+  }
+  if (this.row_count) {
+    output.writeFieldBegin('row_count', Thrift.Type.I64, 3);
+    output.writeI64(this.row_count);
+    output.writeFieldEnd();
+  }
+  output.writeFieldStop();
+  output.writeStructEnd();
+  return;
+};
+

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -41,6 +41,15 @@ var DEFAULT_HOST = 'localhost';
 var DEFAULT_TIMEOUT = 4000;
 
 /**
+ * Default Consistency Level
+ * @private
+ * @constant
+ * @memberOf Connection
+ * @see ttypes.ConsistencyLevel types
+ */
+var DEFAULT_CONSISTENCYLEVEL = 1;
+
+/**
  * Formats CQL properly, paradigm borrowed from node-mysql:
  * https://github.com/felixge/node-mysql/blob/master/lib/client.js#L145-199
  *
@@ -172,6 +181,11 @@ var Connection = function(options){
    * @see https://issues.apache.org/jira/browse/CASSANDRA-3990
    */
   this.cqlVersion = options.cqlVersion;
+
+  /**
+   * Consistency level for cql queries
+   */
+  this.consistencylevel = options.consistencylevel || DEFAULT_CONSISTENCYLEVEL;
 
   /**
    * Ready state of the client
@@ -427,12 +441,24 @@ Connection.prototype.cql = function(cmd, args, options, callback){
     }
   }
 
-  if(options.gzip === true){
-    zlib.deflate(cql, function(err, cqlz){
-      self.execute('execute_cql_query', cqlz, ttype.Compression.GZIP, onReturn);
-    });
-  } else {
-    self.execute('execute_cql_query', cql, ttype.Compression.NONE, onReturn);
+  if (this.cqlVersion === '3.0.0') {
+    if(options.gzip === true){
+      zlib.deflate(cql, function(err, cqlz){
+        self.execute('execute_cql3_query', cqlz, ttype.Compression.GZIP, self.consistencylevel, onReturn);
+      });
+    } else {
+      self.execute('execute_cql3_query', cql, ttype.Compression.NONE, self.consistencylevel, onReturn);
+    }
+  }
+  // fallback to older version
+  else {
+    if(options.gzip === true){
+      zlib.deflate(cql, function(err, cqlz){
+        self.execute('execute_cql_query', cqlz, ttype.Compression.GZIP, onReturn);
+      });
+    } else {
+      self.execute('execute_cql_query', cql, ttype.Compression.NONE, onReturn);
+    }
   }
 };
 

--- a/lib/marshal/index.js
+++ b/lib/marshal/index.js
@@ -38,7 +38,10 @@ var TYPES = {
   'BooleanType':{ ser:Serializers.encodeBoolean, de:Deserializers.decodeBoolean },
   'UUIDType': { ser:Serializers.encodeUUID, de:Deserializers.decodeUUID },
   'CompositeType': { ser:NOOP, de:NOOP },
-  'ReversedType': { ser:IDENTITY, de:IDENTITY }
+  'ReversedType': { ser:IDENTITY, de:IDENTITY },
+  'MapType': { ser:Serializers.encodeBinary, de:Deserializers.decodeBinary },
+  'SetType': { ser:Serializers.encodeBinary, de:Deserializers.decodeBinary },
+  'ListType': { ser:Serializers.encodeBinary, de:Deserializers.decodeBinary }
 };
 
 /**
@@ -52,6 +55,19 @@ function getType(str){
   var classes = str.split('.');
   return classes[classes.length - 1];
 }
+
+function getMapType(str){
+  return 'MapType';
+}
+
+function getSetType(str){
+  return 'SetType';
+}
+
+function getListType(str){
+  return 'ListType';
+}
+
 
 /**
  * Returns the type string inside of the parentheses
@@ -94,7 +110,17 @@ function parseTypeString(type){
     return getCompositeTypes(type);
   } else if(type.indexOf('ReversedType') > -1){
     return getType(getInnerType(type));
-  } else if(type === null || type === undefined) {
+  }
+  else if(type.indexOf('org.apache.cassandra.db.marshal.SetType') > -1){
+    return getSetType(type);
+  }
+  else if(type.indexOf('org.apache.cassandra.db.marshal.ListType') > -1){
+    return getListType(type);
+  }
+  else if(type.indexOf('org.apache.cassandra.db.marshal.MapType') > -1){
+    return getMapType(type);
+  }
+  else if(type === null || type === undefined) {
     return 'BytesType';
   } else {
     return getType(type);

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -49,6 +49,7 @@ var Pool = function(options){
   this.hostPoolSize = options.hostPoolSize ? options.hostPoolSize : 1;
   this.retryInterval = null;
   this.closing = false;
+  this.consistencylevel = options.consistencylevel ? options.consistencylevel : 1;
 
   if(options.getHost){
     this.getHost = options.getHost;
@@ -119,7 +120,8 @@ Pool.prototype.connect = function(callback){
       user: self.user,
       password: self.password,
       timeout: self.timeout,
-      cqlVersion: self.cqlVersion
+      cqlVersion: self.cqlVersion,
+      consistencylevel : self.consistencylevel
     });
 
     connection.on('error', function(err){

--- a/test/helpers/cql3.json
+++ b/test/helpers/cql3.json
@@ -1,5 +1,5 @@
 {
-  "create_ks#cql" : "CREATE KEYSPACE helenus_cql3_test WITH strategy_class=SimpleStrategy AND strategy_options:replication_factor=1",
+  "create_ks#cql" : "CREATE KEYSPACE helenus_cql3_test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
   "use#cql"       : "USE helenus_cql3_test",
   "drop_ks#cql"   : "DROP KEYSPACE helenus_cql3_test",
 


### PR DESCRIPTION
- updated cassandra.thrift
- use new thrift execute_cql3_query for cql3 queries
- do not crash on MapType, SetType and ListType
- Updated CQL3 tests to match latest spec
