### PR TITLE
Update serializers.js

### DIFF
--- a/lib/marshal/serializers.js
+++ b/lib/marshal/serializers.js
@@ -165,7 +165,12 @@ Serializers.encodeDate = function(val){
  * @static
  */
 Serializers.encodeUUID = function(val){
-  return val.toBuffer();
+  if (val instanceof UUID.UUID) {
+    return val.toBuffer();
+  } else {
+    var uuid = new UUID.UUID(val);
+    return uuid.toBuffer();
+  }
 };
 
 /**
@@ -175,7 +180,12 @@ Serializers.encodeUUID = function(val){
  * @static
  */
 Serializers.encodeTimeUUID = function(val){
-  return val.toBuffer();
+  if (val instanceof UUID.TimeUUID) {
+    return val.toBuffer();
+  } else {
+    var timeUUID = new UUID.TimeUUID(val);
+    return timeUUID.toBuffer();
+  }
 };
 
 module.exports = Serializers;


### PR DESCRIPTION
This fixes the issue you run into when trying to use a TimeUUID for a column name on a columnFamily.insert(). The column name cannot be a TimeUUID object, but needs to be a String. (Object keys cannot be objects themselves.)

Example:

``` javascript
keyspace.get('columFamily', function(err, cf) {
    var timeUUID = TimeUUID.fromTimestamp(new Date());
    var column = {};
    column[timeUUID] = JSON.stringify({oy: 'yo'});

    cf.insert('key', column, function(err) {
      if (err) throw(err);
    });
 })
```
