### PR TITLE
Add support for thrift getRange

### DIFF
--- a/lib/cassandra/cassandra_types.js
+++ b/lib/cassandra/cassandra_types.js
@@ -1442,27 +1442,27 @@ KeyRange.prototype.read = function(input) {
 
 KeyRange.prototype.write = function(output) {
   output.writeStructBegin('KeyRange');
-  if (this.start_key) {
+  if (this.start_key !== null) {
     output.writeFieldBegin('start_key', Thrift.Type.STRING, 1);
     output.writeString(this.start_key);
     output.writeFieldEnd();
   }
-  if (this.end_key) {
+  if (this.end_key !== null) {
     output.writeFieldBegin('end_key', Thrift.Type.STRING, 2);
     output.writeString(this.end_key);
     output.writeFieldEnd();
   }
-  if (this.start_token) {
+  if (this.start_token !== null) {
     output.writeFieldBegin('start_token', Thrift.Type.STRING, 3);
     output.writeString(this.start_token);
     output.writeFieldEnd();
   }
-  if (this.end_token) {
+  if (this.end_token !== null) {
     output.writeFieldBegin('end_token', Thrift.Type.STRING, 4);
     output.writeString(this.end_token);
     output.writeFieldEnd();
   }
-  if (this.row_filter) {
+  if (this.row_filter !== null) {
     output.writeFieldBegin('row_filter', Thrift.Type.LIST, 6);
     output.writeListBegin(Thrift.Type.STRUCT, this.row_filter.length);
     for (var iter39 in this.row_filter)
@@ -1476,7 +1476,7 @@ KeyRange.prototype.write = function(output) {
     output.writeListEnd();
     output.writeFieldEnd();
   }
-  if (this.count) {
+  if (this.count !== null) {
     output.writeFieldBegin('count', Thrift.Type.I32, 5);
     output.writeI32(this.count);
     output.writeFieldEnd();
@@ -3665,4 +3665,3 @@ CfSplit.prototype.write = function(output) {
   output.writeStructEnd();
   return;
 };
-

--- a/lib/column_family.js
+++ b/lib/column_family.js
@@ -505,8 +505,14 @@ ColumnFamily.prototype.incr = function (key, column, value, options, callback) {
  * See: http://wiki.apache.org/cassandra/API#KeyRange
  *
  * @param  {Object} options
- *   @param {String} start - the starting key (optional)
- *   @param {String} end   - the ending key (optional)
+ *   <ul>
+ *     <li>
+ *       start: Starting key (optional). If start and end are left blank getRange will return
+ *       all rows.
+ *     </li>
+ *     <li>end: End key (optional).</li>
+ *     <li>rowCount: Limit total number of rows to return, defaults to all (option)</li>
+ *   </ul>
  * @return {Stream}
  */
 ColumnFamily.prototype.getRange = function (options) {
@@ -517,7 +523,10 @@ ColumnFamily.prototype.getRange = function (options) {
       consistency = options.consistency || options.consistencyLevel || DEFAULT_READ_CONSISTENCY,
       predicate = getSlicePredicate(options, this.columnMarshaller),
       iterations = 0,
+      bufferSize = 100,
+      rowCount = options.rowCount,
       stream = new Stream(),
+      totalRowCount = 0,
       keyRange, keyRangeOptions = {};
 
   keyRangeOptions.start_key = options.start || '';
@@ -546,14 +555,20 @@ ColumnFamily.prototype.getRange = function (options) {
       stream.emit('data', Row.fromThrift(self.keyMarshaller.deserialize(row.key), row.columns, self));
       // Track how many items we have emitted
       count += 1;
+      totalRowCount += 1;
+
+      if (rowCount !== undefined && totalRowCount >= rowCount) {
+        break;
+      }
     }
 
     iterations += 1;
 
-    if (count > 0){
+    if (rowCount !== undefined && totalRowCount >= rowCount) {
+      stream.emit('end');
+    } else if (count > 0){
       var startKey = val[len - 1].key;
 
-      delete keyRangeOptions.start_token;
       keyRangeOptions.start_key = startKey;
 
       keyRange = new ttype.KeyRange(keyRangeOptions);

--- a/lib/column_family.js
+++ b/lib/column_family.js
@@ -1,4 +1,5 @@
 var util = require('util'),
+    Stream = require('stream').Stream,
     Marshal = require('./marshal'),
     Column = require('./column'),
     CounterColumn = require('./counter_column'),
@@ -493,5 +494,88 @@ ColumnFamily.prototype.incr = function (key, column, value, options, callback) {
 
   this.connection.execute('batch_mutate', batch, consistency, callback);
 };
+
+
+/**
+ * Performces a key range slice on the CF.
+ *
+ * Start and end keys can be specified in the options. If no keys are specified
+ * then the entire column range space will be iterated over.
+ *
+ * See: http://wiki.apache.org/cassandra/API#KeyRange
+ *
+ * @param  {Object} options
+ *   @param {String} start - the starting key
+ *   @param {String} end   - the ending key
+ * @return {Stream}
+ */
+ColumnFamily.prototype.getRange = function (options) {
+
+  options = options || {};
+
+  var self = this,
+      consistency = options.consistency || options.consistencyLevel || DEFAULT_READ_CONSISTENCY,
+      predicate = getSlicePredicate(options, this.columnMarshaller),
+      iterations = 0,
+      stream = new Stream(),
+      keyRange, keyRangeOptions = {};
+
+  if (options.start && options.end) {
+    keyRangeOptions.start_key = options.start;
+    keyRangeOptions.end_key = options.end;
+  } else {
+    // Fetch all the keys
+    keyRangeOptions.start_token = '0';
+    keyRangeOptions.end_token = '0';
+  }
+
+  keyRange = new ttype.KeyRange(keyRangeOptions);
+
+  function iterator () {
+    self.connection.execute('get_range_slices', columnParent(self), predicate,
+                             keyRange, consistency, onComplete);
+  }
+
+  function onComplete(err, val){
+    if(err){
+      stream.emit('error', err);
+      return;
+    }
+
+    var i = 0, len = val.length, row, count = 0;
+    for(; i < len; i += 1){
+      // First key is a duplicate from the last iteration.
+      if (iterations > 0 && i === 0)
+        continue;
+
+      row = val[i];
+      stream.emit('data', Row.fromThrift(self.keyMarshaller.deserialize(row.key), row.columns, self));
+      // Track how many items we have emitted
+      count += 1;
+    }
+
+    iterations += 1;
+
+    if (count > 0){
+      var startKey = val[len - 1].key;
+
+      delete keyRangeOptions.start_token;
+      keyRangeOptions.start_key = startKey;
+
+      keyRange = new ttype.KeyRange(keyRangeOptions);
+
+      process.nextTick(iterator);
+
+    } else {
+      stream.emit('end');
+    }
+  }
+
+  // Start our stream next tick
+  process.nextTick(iterator);
+
+  return stream;
+};
+
 
 module.exports = ColumnFamily;

--- a/lib/column_family.js
+++ b/lib/column_family.js
@@ -505,8 +505,8 @@ ColumnFamily.prototype.incr = function (key, column, value, options, callback) {
  * See: http://wiki.apache.org/cassandra/API#KeyRange
  *
  * @param  {Object} options
- *   @param {String} start - the starting key
- *   @param {String} end   - the ending key
+ *   @param {String} start - the starting key (optional)
+ *   @param {String} end   - the ending key (optional)
  * @return {Stream}
  */
 ColumnFamily.prototype.getRange = function (options) {
@@ -520,14 +520,8 @@ ColumnFamily.prototype.getRange = function (options) {
       stream = new Stream(),
       keyRange, keyRangeOptions = {};
 
-  if (options.start && options.end) {
-    keyRangeOptions.start_key = options.start;
-    keyRangeOptions.end_key = options.end;
-  } else {
-    // Fetch all the keys
-    keyRangeOptions.start_token = '0';
-    keyRangeOptions.end_token = '0';
-  }
+  keyRangeOptions.start_key = options.start || '';
+  keyRangeOptions.end_key = options.end || '';
 
   keyRange = new ttype.KeyRange(keyRangeOptions);
 

--- a/test/helpers/thrift.js
+++ b/test/helpers/thrift.js
@@ -6,6 +6,7 @@ module.exports = {
   "cf_counter"   : "cf_counter_test",
   "cf_reversed"   : "cf_reversed_test",
   "cf_composite_nested_reversed"   : "cf_composite_nested_reversed_test",
+  "cf_range"   : "cf_range_test",
   "cf_invalid"   : "cf_invalid_test",
   "cf_error"     : "<!`~;/?}]|\\-",
   "cf_standard_options"   : {
@@ -54,6 +55,11 @@ module.exports = {
     "key_validation_class" : "UTF8Type",
     "default_validation_class" : "UTF8Type",
     "comparator_type" : "CompositeType(TimeUUIDType(reversed=true),UTF8Type)"
+  },
+  "cf_range_options": {
+    "key_validation_class" : "UTF8Type",
+    "default_validation_class" : "UTF8Type",
+    "comparator_type" : "UTF8Type"
   },
   "standard_row_key" : "standard_row_1",
   "standard_insert_values" : {


### PR DESCRIPTION
This pull request builds on @calvinfo's work to add getRange. 
- Added tests
- Added option to limit number of rows returned
- Fixed thrift handling of falsey values for KeyRange
