### PR TITLE
Adding .noDeserialize to Row.slice / Row.nameSlice

### DIFF
--- a/lib/row.js
+++ b/lib/row.js
@@ -164,6 +164,7 @@ Row.prototype.nameSlice = function(start, end){
     }
   }
 
+  this._schema.noDeserialize = true;
   return new Row({ key:this.key, columns:matches }, this._schema);
 };
 
@@ -177,6 +178,7 @@ Row.prototype.slice = function(start, end){
   start = start || 0;
 
   var matches = Array.prototype.slice.call(this, start, end);
+  this._schema.noDeserialize = true;
   return new Row({ key:this.key, columns:matches }, this._schema);
 };
 

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -612,6 +612,21 @@ module.exports = {
     test.finish();
   },
 
+  'test row.nameSlice with UTF8 data':function(test, assert){
+    var key = config.standard_row_key + '-utf8-nameSlice',
+        opts = { 'utf8-test' : 'åbcd' };
+
+    cf_standard.insert(key, opts, function(err){
+      assert.ifError(err);
+      cf_standard.get(key, function(err, row){
+        assert.ifError(err);
+        var nameSlicedRow = row.nameSlice('a', 'z');
+        assert.ok(nameSlicedRow.get('utf8-test').value === 'åbcd');
+        test.finish();
+      });
+    });
+  },
+
   'test row.slice':function(test, assert){
     var row = row_standard.slice(1, 3);
     assert.ok(row instanceof Helenus.Row);
@@ -620,6 +635,21 @@ module.exports = {
     assert.ok(row.get('one').value === 'a');
     assert.ok(row.get('three').value === 'c');
     test.finish();
+  },
+
+  'test row.slice with UTF8 data':function(test, assert){
+    var key = config.standard_row_key + '-utf8-slice',
+        opts = { 'utf8-test' : 'åbcd' };
+
+    cf_standard.insert(key, opts, function(err){
+      assert.ifError(err);
+      cf_standard.get(key, function(err, row){
+        assert.ifError(err);
+        var slicedRow = row.slice(0, 10);
+        assert.ok(slicedRow.get('utf8-test').value === 'åbcd');
+        test.finish();
+      });
+    });
   },
 
   'test row.toString and row.inspect':function(test, assert){


### PR DESCRIPTION
We were heaving an issue where already decoded data was ran trough the deserializers again when doing a slice.

Setting the `noDeserialize` key on the schema when creating new `Row` objects mitigates this.
I've added a couple of testcases that should catch this in the future.
