### PR TITLE
Cassandra long is now Bignum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ node_js:
 
 env:
   - CASSANDRA_VERSION=1.0.12
-  - CASSANDRA_VERSION=1.1.10
-  - CASSANDRA_VERSION=1.2.3
+  - CASSANDRA_VERSION=1.1.12
+  - CASSANDRA_VERSION=1.2.5
 
 before_install:
   - sudo apt-get install libjna-java

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -6,7 +6,8 @@ var util = require('util'),
     Row = require('./row'),
     zlib = require('zlib'),
     Keyspace = require('./keyspace'),
-    errors = require('./errors');
+    errors = require('./errors'),
+    bignum = require('bignum');
 
 /**
  * A No-Operation function for default callbacks
@@ -97,7 +98,7 @@ function escapeCQL(val) {
     return val.toString('hex');
   }
 
-  if(typeof val === 'number'){
+  if((typeof val === 'number') || (val instanceof bignum)){
     return val.toString();
   }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -98,7 +98,7 @@ function escapeCQL(val) {
     return val.toString('hex');
   }
 
-  if((typeof val === 'number') || (val instanceof bignum)){
+  if((typeof val === 'number') || (typeof val.toNumber == "function" )){
     return val.toString();
   }
 

--- a/lib/marshal/deserializers.js
+++ b/lib/marshal/deserializers.js
@@ -1,5 +1,6 @@
 var UUID = require('../uuid').UUID,
-    TimeUUID = require('../uuid').TimeUUID;
+    TimeUUID = require('../uuid').TimeUUID,
+    bignum = require('bignum');
 
 /**
  * Deserializers for various types
@@ -10,11 +11,11 @@ var Deserializers = {};
 var decodeLongFromBuffer = function(buf) {
     var negative = buf.readInt8(0) < 0;
     if(negative) {
-      //TODO: replace this with a better negative reading function that does up to 53 bytes
-      return buf.readInt32BE(4);
+        return bignum("FFFFFFFFFFFFFFFF",16).sub(bignum.fromBuffer(buf)).add(1).neg();
     } else {
-      return parseInt(buf.toString('hex'), 16);
+        return bignum.fromBuffer(buf);
     }
+    return result;
 }
 
 Deserializers.decodeInteger = function(bits, val, signed){
@@ -182,7 +183,7 @@ Deserializers.decodeDate = function(val){
   }
 
   var date = Deserializers.decodeLong(val);
-  return new Date(date);
+  return new Date(date.toNumber());
 };
 
 /**

--- a/lib/marshal/serializers.js
+++ b/lib/marshal/serializers.js
@@ -1,4 +1,5 @@
-var UUID = require('../uuid');
+var UUID = require('../uuid'),
+    bignum = require('bignum');
 
 /**
  * Serializers for various types
@@ -14,22 +15,20 @@ var Serializers = {};
  * @static
  */
 Serializers.encodeInteger = function(bits, num){
-  var buf = new Buffer(bits/8), func;
-
-  if(typeof num !== 'number'){
-    num = parseInt(num, 10);
-  }
-
   switch(bits){
-    case 32: buf.writeUInt32BE(num, 0); break;
+    case 32:
+        var buf = new Buffer(bits/8), func;
+        if(typeof num !== 'number'){
+            num = parseInt(num, 10);
+        }
+        buf.writeUInt32BE(num, 0);
+        return buf;
     case 64:
-      var hex = num.toString(16);
-      hex = new Array(17 - hex.length).join('0') + hex;
-      buf.writeUInt32BE(parseInt(hex.slice( 0, 8), 16), 0);
-      buf.writeUInt32BE(parseInt(hex.slice( 8, 16), 16), 4);
+      if(typeof num !== 'object'){
+        num = bignum(num, 10);
+      }
+      return num.toBuffer({size:8});
   }
-
-  return buf;
 };
 
 /**
@@ -76,11 +75,11 @@ Serializers.encodeUTF8 = function(val){
   if(Buffer.isBuffer(val)){
     return val;
   }
-  
+
   if(val === undefined || val === null){
     val = '';
   }
-  
+
   return new Buffer(val.toString(), 'utf8');
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   , "dependencies": {
       "helenus-thrift": "0.7.3"
     , "node-uuid": "1.3.3"
+    , "bignum": "0.6.0"
     }
   , "devDependencies": {
       "whiskey": "git://github.com/cloudkick/whiskey.git#b3c5bc23e30c95e46083bc7628c2557c1c15ec95"

--- a/test/cql2.js
+++ b/test/cql2.js
@@ -148,7 +148,7 @@ module.exports = {
       assert.ifError(err);
       assert.ok(res.length === 1);
       assert.ok(res[0] instanceof Helenus.Row);
-      assert.ok(res[0].get('foo').value === 10);
+      assert.ok(res[0].get('foo').value.eq(10));
       test.finish();
     });
   },
@@ -160,7 +160,7 @@ module.exports = {
         assert.ifError(err);
         assert.ok(res.length === 1);
         assert.ok(res[0] instanceof Helenus.Row);
-        assert.ok(res[0].get('foo').value === 20);
+        assert.ok(res[0].get('foo').value.eq(20));
         test.finish();
       });
     });
@@ -184,7 +184,7 @@ module.exports = {
       assert.ifError(err);
       assert.ok(res.length === 1);
       assert.ok(res[0] instanceof Helenus.Row);
-      assert.ok(res[0].get('count').value === 1);
+      assert.ok(res[0].get('count').value.eq(1));
       test.finish();
     });
   },
@@ -204,7 +204,7 @@ module.exports = {
       assert.ifError(err);
       assert.ok(res.length === 1);
       assert.ok(res[0] instanceof Helenus.Row);
-      assert.ok(res[0].get('count').value === 1);
+      assert.ok(res[0].get('count').value.eq(1));
       test.finish();
     });
   },

--- a/test/cql3.js
+++ b/test/cql3.js
@@ -123,7 +123,7 @@ module.exports = {
   'test cql static counter CF select':testCql(config['static_select_cnt#cql'], function(test, assert, err, res){
       assert.ok(res.length === 1);
       assert.ok(res[0] instanceof Helenus.Row);
-      assert.ok(res[0].get('cnt').value === 10);
+      assert.ok(res[0].get('cnt').value.eq(10));
   }),
 
   'test cql static counter CF incr and select':function(test, assert){
@@ -134,7 +134,7 @@ module.exports = {
         assert.ifError(err);
         assert.ok(res.length === 1);
         assert.ok(res[0] instanceof Helenus.Row);
-        assert.ok(res[0].get('cnt').value === 20);
+        assert.ok(res[0].get('cnt').value.eq(20));
         test.finish();
       });
     });
@@ -147,7 +147,7 @@ module.exports = {
   'test cql static CF count':testCql(config['static_count#cql'], function(test, assert, err, res){
     assert.ok(res.length === 1);
     assert.ok(res[0] instanceof Helenus.Row);
-    assert.ok(res[0].get('count').value === 1);
+    assert.ok(res[0].get('count').value.eq(1));
   }),
 
   'test cql static CF error':function(test, assert){
@@ -163,7 +163,7 @@ module.exports = {
   'test cql static CF count with gzip':testCql(config['static_count#cql'], {gzip:true}, function(test, assert, err, res){
     assert.ok(res.length === 1);
     assert.ok(res[0] instanceof Helenus.Row);
-    assert.ok(res[0].get('count').value === 1);
+    assert.ok(res[0].get('count').value.eq(1));
   }),
 
   'test cql static CF delete':function(test, assert){
@@ -256,7 +256,7 @@ module.exports = {
     assert.ok(res[0] instanceof Helenus.Row);
     assert.strictEqual(res[0].length, 3);
     assert.strictEqual(res[0].get('number').value, 1);
-    assert.strictEqual(res[0].get('longnumber').value, 25);
+    assert.strictEqual(res[0].get('longnumber').value.toNumber(), 25);
     assert.strictEqual(res[0].get('varnumber').value, 36);
   }),
   'test cql integers CF select negative numbers':testCql(config['integers_select2#cql'], function(test, assert, err, res){
@@ -264,7 +264,7 @@ module.exports = {
     assert.ok(res[0] instanceof Helenus.Row);
     assert.strictEqual(res[0].length, 3);
     assert.strictEqual(res[0].get('number').value, -1);
-    assert.strictEqual(res[0].get('longnumber').value, -25);
+    assert.ok(res[0].get('longnumber').value.eq(-25));
     assert.strictEqual(res[0].get('varnumber').value, -36);
   }),
   'test cql integers CF select negative numbers with 3 byte varint':testCql(config['integers_select3#cql'], function(test, assert, err, res){
@@ -272,7 +272,7 @@ module.exports = {
     assert.ok(res[0] instanceof Helenus.Row);
     assert.strictEqual(res[0].length, 3);
     assert.strictEqual(res[0].get('number').value, -2);
-    assert.strictEqual(res[0].get('longnumber').value, -25);
+    assert.ok(res[0].get('longnumber').value.eq(-25));
     assert.strictEqual(res[0].get('varnumber').value, -8388607);//test a 3 byte-long variable integer
   }),
 

--- a/test/helpers/cql3.json
+++ b/test/helpers/cql3.json
@@ -5,7 +5,7 @@
   "drop_ks#cql"   : "DROP KEYSPACE helenus_cql3_test",
 
   "static_create_cf#cql"     : "CREATE COLUMNFAMILY cql_test (id text, foo text, PRIMARY KEY (id))",
-  "static_create_cnt_cf#cql" : "CREATE TABLE cql_cnt_test (key varchar PRIMARY KEY, cnt counter)",
+  "static_create_cnt_cf#cql" : "CREATE TABLE cql_cnt_test (key int PRIMARY KEY, cnt counter)",
   "static_drop_cf#cql"       : "DROP COLUMNFAMILY cql_test",
   "static_update#cql"        : "UPDATE cql_test SET foo='bar' WHERE id='foobar'",
   "static_update_cnt#cql"    : "UPDATE cql_cnt_test SET cnt=cnt+10 WHERE key=1",
@@ -23,7 +23,7 @@
   "dynamic_update#vals1"  : ["2012-03-01+0000", 10, "www.example.com"],
   "dynamic_update#vals2"  : ["2012-03-01+0000", 10, "www.foo.com"],
   "dynamic_update#vals3"  : ["2012-03-02+0000", 10, "www.foo.com"],
-  "dynamic_select1#cql"   : "SELECT ts FROM clicks WHERE userid = '10'",
+  "dynamic_select1#cql"   : "SELECT ts FROM clicks WHERE userid = 10",
   "dynamic_select2#cql"   : "SELECT userid, url, ts FROM clicks WHERE userid = 10 AND url = 'www.foo.com'",
 
   "dense_create_cf#cql" : "CREATE TABLE connections (userid int, ip text, port int, ts timestamp, PRIMARY KEY (userid, ip, port)) WITH COMPACT STORAGE",
@@ -31,7 +31,7 @@
   "dense_update#vals1"  : ["2012-03-01+0000", 10, "192.168.1.1", 8080],
   "dense_update#vals2"  : ["2012-03-01+0000", 10, "192.168.1.1", 1337],
   "dense_update#vals3"  : ["2012-03-02+0000", 10, "192.168.1.1", 1337],
-  "dense_select1#cql"   : "SELECT ts, port FROM connections WHERE userid = '10'",
+  "dense_select1#cql"   : "SELECT ts, port FROM connections WHERE userid = 10",
   "dense_select2#cql"   : "SELECT userid, ip, port, ts FROM connections WHERE userid = 10 AND ip = '192.168.1.1' AND port = 1337",
 
   "sparse_create_cf#cql" : "CREATE TABLE timeline (userid int, posted_at timestamp, body text, posted_by text, PRIMARY KEY (userid, posted_at))",

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -2,7 +2,8 @@ var config = require('./helpers/thrift'),
     system = require('./helpers/connection'),
     badSystem = require('./helpers/bad_connection'),
     Helenus, conn, ks, cf_standard, row_standard, cf_composite, cf_counter,
-    cf_reversed, cf_composite_nested_reversed;
+    cf_reversed, cf_composite_nested_reversed,
+    bignum = require('bignum');
 
 module.exports = {
   'setUp':function(test, assert){
@@ -297,9 +298,9 @@ module.exports = {
       cf_composite.get(key, options, function(err, row){
         assert.ifError(err);
         assert.ok(row.count === 3);
-        assert.ok(row[0].name[0] === 3);
-        assert.ok(row[1].name[0] === 4);
-        assert.ok(row[2].name[0] === 5);
+        assert.ok(row[0].name[0].eq(3));
+        assert.ok(row[1].name[0].eq(4));
+        assert.ok(row[2].name[0].eq(5));
         test.finish();
       });
     });
@@ -327,7 +328,7 @@ module.exports = {
       cf_composite.get(key, options, function(err, row){
         assert.ifError(err);
         assert.ok(row.count === 1);
-        assert.ok(row[0].name[0] === 4);
+        assert.ok(row[0].name[0].eq(4));
         test.finish();
       });
     });
@@ -435,8 +436,8 @@ module.exports = {
       cf_standard.get(key, function(err, row){
         assert.ifError(err);
         var col = row.get('long-test');
-        assert.ok(typeof col.value === 'number');
-        assert.ok(col.value === 123456789012345);
+        assert.ok(col.value instanceof bignum);
+        assert.ok(col.value.eq(123456789012345));
         test.finish();
       });
     });


### PR DESCRIPTION
Some groundwork porting long `number` to `bignum` https://github.com/justmoon/node-bignum
Tests are passed by forcing it to use new bignum so this will break current API
