### PR TITLE
Mitigate cryptic "cannot parse as hex bytes" error via explicit `cqlVersion` test

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -422,6 +422,13 @@ Connection.prototype.cql = function(cmd, args, options, callback){
     callback = NOOP;
   }
 
+  //verify that cqlVersion was set to prevent cryptic "cannot parse as hex bytes" errors
+  if (!this.cqlVersion) return callback(new Error("'cqlVersion' is not set; " +
+      "you have to set it explicitly as part of options when creating the " +
+      "connection pool (for example):" +
+      "var pool = new helenus.ConnectionPool({hosts: [\"localhost:9160\"]," +
+      "cqlVersion: \"3.0.0\"});"));
+
   var cql, escaped = [], self = this;
 
   if(args){

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -449,7 +449,7 @@ Connection.prototype.cql = function(cmd, args, options, callback){
     }
   }
 
-  if (this.cqlVersion === '3.0.0' || this.version[0] === '19' && this.version[1] > '33') {
+  if (this.cqlVersion === '3.0.0' || (this.version[0] === '19' && this.version[1] > '33')) {
     if(options.gzip === true){
       zlib.deflate(cql, function(err, cqlz){
         self.execute('execute_cql3_query', cqlz, ttype.Compression.GZIP, self.consistencylevel, onReturn);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -422,13 +422,6 @@ Connection.prototype.cql = function(cmd, args, options, callback){
     callback = NOOP;
   }
 
-  //verify that cqlVersion was set to prevent cryptic "cannot parse as hex bytes" errors
-  if (!this.cqlVersion) return callback(new Error("'cqlVersion' is not set; " +
-      "you have to set it explicitly as part of options when creating the " +
-      "connection pool (for example):" +
-      "var pool = new helenus.ConnectionPool({hosts: [\"localhost:9160\"]," +
-      "cqlVersion: \"3.0.0\"});"));
-
   var cql, escaped = [], self = this;
 
   if(args){
@@ -456,7 +449,7 @@ Connection.prototype.cql = function(cmd, args, options, callback){
     }
   }
 
-  if (this.cqlVersion === '3.0.0' && this.version[0] === '19' && this.version[1] > '33') {
+  if (this.cqlVersion === '3.0.0' || this.version[0] === '19' && this.version[1] > '33') {
     if(options.gzip === true){
       zlib.deflate(cql, function(err, cqlz){
         self.execute('execute_cql3_query', cqlz, ttype.Compression.GZIP, self.consistencylevel, onReturn);


### PR DESCRIPTION
This should mitigate errors and confusion of the type described in #108.
