### PR TITLE
Support latest Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
       "test": "make test"
     }
   , "main": "index"
-  , "engines": { "node": ">=0.6.0 <0.9.0" }
+  , "engines": { "node": ">=0.6.0" }
 }


### PR DESCRIPTION
Any reason Node <= 9 required?  If not this can be merged.
