### PR TITLE
Allow for boolean parameters in cql calls

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -102,7 +102,7 @@ function escapeCQL(val) {
     return val.toString('hex');
   }
 
-  if(typeof val === 'number'){
+  if(typeof val === 'number' || typeof val === 'boolean'){
     return val.toString();
   }
 

--- a/test/cql2.js
+++ b/test/cql2.js
@@ -95,6 +95,17 @@ module.exports = {
     });
   },
 
+  'test cql update with boolean value':function(test, assert){
+    conn.cql(config['update_uuid#cql'], [true, 'bb85f040-30c3-11e3-aa6e-0800200c9a66'], function(err, res){
+      assert.ifError(err);
+      conn.cql(config['select_uuid#cql'], ['bb85f040-30c3-11e3-aa6e-0800200c9a66'], function(err, res){
+        assert.ifError(err);
+        assert.ok(res[0].get('body').value === 'true');
+        test.finish();
+      });
+    });
+  },
+
   'test cql update reversed':function(test, assert){
     conn.cql(config['update_reversed#cql'], function(err, res){
       assert.ifError(err);


### PR DESCRIPTION
Boolean parameter support seemed to have been removed in https://github.com/simplereach/helenus/commit/e2828a5843b0f2b8031f61f218f590dca5c46c0e . This PR brings it back and adds a small test for it.
