### PR TITLE
Add query-level tunable consistency

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -187,7 +187,8 @@ var Connection = function(options){
   this.cqlVersion = options.cqlVersion;
 
   /**
-   * Consistency level for cql queries
+   * Default consistency level for cql queries. Can be overriden by the
+   * options in each cql query
    */
   this.consistencylevel = options.consistencylevel || DEFAULT_CONSISTENCYLEVEL;
 
@@ -426,13 +427,16 @@ Connection.prototype.cql = function(cmd, args, options, callback){
     callback = NOOP;
   }
 
-  var cql, escaped = [], self = this;
+  var cql, consistency_level, escaped = [], self = this;
 
   if(args){
     cql = new Buffer(formatCQL(cmd, args));
   } else {
     cql = new Buffer(cmd);
   }
+
+  // allow the query options to override the default consistency
+  consistency_level = options.consistencyLevel || self.consistencylevel;
 
   function onReturn(err, res){
     if (err){
@@ -457,19 +461,19 @@ Connection.prototype.cql = function(cmd, args, options, callback){
     if(v===3)
       if(options.gzip === true){
         zlib.deflate(cql, function(err, cqlz){
-          self.execute('execute_cql3_query', cqlz, ttype.Compression.GZIP, self.consistencylevel, onReturn);
+          self.execute('execute_cql3_query', cqlz, ttype.Compression.GZIP, consistency_level, onReturn);
         });
       } else {
-        self.execute('execute_cql3_query', cql, ttype.Compression.NONE, self.consistencylevel, onReturn);
+        self.execute('execute_cql3_query', cql, ttype.Compression.NONE, consistency_level, onReturn);
       }
     else
       if(options.gzip === true){
-      zlib.deflate(cql, function(err, cqlz){
-        self.execute('execute_cql_query', cqlz, ttype.Compression.GZIP, onReturn);
-      });
-    } else {
-      self.execute('execute_cql_query', cql, ttype.Compression.NONE, onReturn);
-    }
+        zlib.deflate(cql, function(err, cqlz){
+          self.execute('execute_cql_query', cqlz, ttype.Compression.GZIP, onReturn);
+        });
+      } else {
+        self.execute('execute_cql_query', cql, ttype.Compression.NONE, onReturn);
+      }
   }
 
 

--- a/test/helpers/cql3.json
+++ b/test/helpers/cql3.json
@@ -1,8 +1,8 @@
 {
-  "create_ks#cql" : "CREATE KEYSPACE helenus_cql3_test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
-  "create_ks#cql_v1" : "CREATE KEYSPACE helenus_cql3_test WITH strategy_class=SimpleStrategy AND strategy_options:replication_factor=1",
-  "use#cql"       : "USE helenus_cql3_test",
-  "drop_ks#cql"   : "DROP KEYSPACE helenus_cql3_test",
+  "create_ks#cql"     : "CREATE KEYSPACE helenus_cql3_test WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 3 };",
+  "create_ks#cql_v1"  : "CREATE KEYSPACE helenus_cql3_test WITH strategy_class=SimpleStrategy AND strategy_options:replication_factor=3",
+  "use#cql"           : "USE helenus_cql3_test",
+  "drop_ks#cql"       : "DROP KEYSPACE helenus_cql3_test",
 
   "static_create_cf#cql"     : "CREATE COLUMNFAMILY cql_test (id text, foo text, PRIMARY KEY (id))",
   "static_create_cnt_cf#cql" : "CREATE TABLE cql_cnt_test (key varchar PRIMARY KEY, cnt counter)",

--- a/test/thrift.js
+++ b/test/thrift.js
@@ -49,15 +49,15 @@ module.exports = {
     // Add error handler to avoid uncaught exception.
     badConn.on('error', function (err) { assert.isDefined(err); });
     badConn.connect(function(err, keyspace) {
-       assert.isDefined(err);
-       badConn.createKeyspace(config.keyspace, function(err){
+      assert.isDefined(err);
+      badConn.createKeyspace(config.keyspace, function(err){
+        assert.isDefined(err);
+        badConn.dropKeyspace(config.keyspace, function(err){
           assert.isDefined(err);
-          badConn.dropKeyspace(config.keyspace, function(err){
-            assert.isDefined(err);
-            badConn.close();
-            test.finish();
-          });
-       });
+          badConn.close();
+          test.finish();
+        });
+      });
     });
   },
 
@@ -705,8 +705,8 @@ module.exports = {
       cf_standard.get(config.standard_row_key, function(err, row){
         assert.ifError(err);
         assert.ok(row.count === 3);
+        test.finish();
       });
-      test.finish();
     });
   },
 
@@ -760,8 +760,8 @@ module.exports = {
       cf_standard.get(key, function(err, row){
         assert.ifError(err);
         assert.ok(row.count === 0);
+        test.finish();
       });
-      test.finish();
     });
   },
 
@@ -771,8 +771,8 @@ module.exports = {
       cf_standard.get(config.standard_row_key, function(err, row){
         assert.ifError(err);
         assert.ok(row.count === 0);
+        test.finish();
       });
-      test.finish();
     });
   },
 


### PR DESCRIPTION
This PR provides the ability to supply a `consistencyLevel` query option that specifies the consistency level to use for a CQL3 query.

The `connection.consistencylevel` that is provided when creating the connection is now referred to as the "default consistency level" for queries.

To test, I changed the keyspace used in CQL3 tests to have RF=3. Since the default consistency level of the connections is ONE, all tests continue to succeed. To verify the query-level consistency, I try a simple query overriding the consistency to quorum and ensure it fails.
