### PR TITLE
Wait to send 'connect' event until pool is fully initialized (Issue #134)

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -95,10 +95,19 @@ Pool.prototype.connect = function(callback){
         keyspace.connection = self;
       }
       self.clients.push(connection);
-      if (connected === 1) {
-        self.emit('connect');
-        callback(null, keyspace);
+      if (len === 1) {
+        if (connected === 1) {
+          self.emit('connect');
+          callback(null, keyspace);
+        }
+      } else {
+        // if a pool is configured, wait until all have been added to array before emit('connect')
+        if (finished === len) {
+          self.emit('connect');
+          callback(null, keyspace);
+        }
       }
+
       if (self.closing) {
         connection.close();
       }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -102,6 +102,7 @@ Pool.prototype.connect = function(callback){
         }
       } else {
         // if a pool is configured, wait until all have been added to array before emit('connect')
+        // Another option would be to emit a different event when the pool is ready.  Maybe 'poolReady'.
         if (finished === len) {
           self.emit('connect');
           callback(null, keyspace);


### PR DESCRIPTION
The 'connect' event is sent prematurely in the case when a connection pool is configured.
