### PR TITLE
Updated microtime dependency to be native javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     , "node-uuid": "1.3.3"
     }
   , "optionalDependencies": {
-      "microtime": "0.4.0"
+      "microtime-nodejs": "1.0.0"
     }
   , "devDependencies": {
       "whiskey": "git://github.com/cloudkick/whiskey.git#b3c5bc23e30c95e46083bc7628c2557c1c15ec95"


### PR DESCRIPTION
microtime is dependent on nan which is a compatibility layer that doesn't work as well on Windows.  microtime-nodejs is a pure javascript native version.
